### PR TITLE
ci: automatically deploy every Monday at 14h00

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,11 +2,8 @@ name: Deploy
 
 on:
   workflow_dispatch:
-    inputs:
-      perform_deploy:
-        required: true
-        description: Confirm Deploy
-        type: boolean
+  schedule:
+    - cron: "0 14 * * MON"
 
 jobs:
   deploy:


### PR DESCRIPTION
As we don't need to create a new NPM version after each merge, it seems confortable to schedule a new on every Monday at 2pm (besides be able to trigger one manually).