### PR TITLE
fix(client): adjust DefaultValues so it contains defaultPageSize

### DIFF
--- a/packages/clients/src/bridge.ts
+++ b/packages/clients/src/bridge.ts
@@ -3,7 +3,7 @@ export { isJSONObject } from './helpers/json'
 export { waitForResource } from './internal/async/interval-retrier'
 export type { WaitForOptions } from './internal/async/interval-retrier'
 export { API } from './scw/api'
-export type { DefaultValues } from './scw/client-ini-profile'
+export type { DefaultValues } from './scw/client-settings'
 export type {
   Money,
   ServiceInfo,

--- a/packages/clients/src/internals.ts
+++ b/packages/clients/src/internals.ts
@@ -4,7 +4,7 @@ export type { RequestInterceptor } from './internal/interceptors/request'
 export type { ResponseInterceptor } from './internal/interceptors/response'
 export { API } from './scw/api'
 export { authenticateWithSessionToken } from './scw/auth'
-export type { DefaultValues } from './scw/client-ini-profile'
+export type { DefaultValues } from './scw/client-settings'
 export {
   marshalScwFile,
   marshalMoney,

--- a/packages/clients/src/scw/client-ini-profile.ts
+++ b/packages/clients/src/scw/client-ini-profile.ts
@@ -28,7 +28,7 @@ export interface AuthenticationSecrets {
  *
  * @public
  */
-export interface DefaultValues {
+export interface ProfileDefaultValues {
   /**
    * APIURL overrides the API URL of the Scaleway API to the given URL.
    * Change that if you want to direct requests to a different endpoint.
@@ -65,7 +65,7 @@ export interface DefaultValues {
  *
  * @public
  */
-export type Profile = Partial<DefaultValues & AuthenticationSecrets>
+export type Profile = Partial<ProfileDefaultValues & AuthenticationSecrets>
 
 /**
  * Verifies that the payload contains both the accessKey and the secretKey.

--- a/packages/clients/src/scw/client-settings.ts
+++ b/packages/clients/src/scw/client-settings.ts
@@ -7,7 +7,19 @@ import {
   isURL,
   isZone,
 } from '../internal/validations/string-validation'
-import type { DefaultValues } from './client-ini-profile'
+import type { ProfileDefaultValues } from './client-ini-profile'
+
+/**
+ * Holds default values of settings.
+ *
+ * @public
+ */
+export type DefaultValues = ProfileDefaultValues & {
+  /**
+   * The default number of results when requesting a paginated resource.
+   */
+  defaultPageSize?: number
+}
 
 /**
  * Settings hold the values of all client options.


### PR DESCRIPTION
Context: the DefaultValues type was only containing default values from a profile, and not the ones from Settings. It leads to some typecheck errors when it's needed in marshallers.