### PR TITLE
chore: use `export type *` since its support in TypeScript 5

### DIFF
--- a/packages/clients/src/api/instance/v1/index.ts
+++ b/packages/clients/src/api/instance/v1/index.ts
@@ -1,4 +1,4 @@
 export { InstanceV1UtilsAPI as API } from './api.utils'
 export * from './content.gen'
-export * from './types.gen'
-export * from './types.utils'
+export type * from './types.gen'
+export type * from './types.utils'

--- a/packages/clients/src/api/k8s/v1/index.ts
+++ b/packages/clients/src/api/k8s/v1/index.ts
@@ -1,5 +1,5 @@
 export { K8SUtilsAPI as API } from './api.utils'
 export * from './content.gen'
-export * from './types.gen'
-export * from './types.utils'
+export type * from './types.gen'
+export type * from './types.utils'
 export * as ValidationRules from './validation-rules.gen'

--- a/packages/clients/src/api/lb/v1/index.ts
+++ b/packages/clients/src/api/lb/v1/index.ts
@@ -1,4 +1,4 @@
 export { LbV1UtilsAPI as API, LbZonedV1UtilsAPI as ZonedAPI } from './api.utils'
 export * from './content.gen'
-export * from './types.gen'
-export * from './types.utils'
+export type * from './types.gen'
+export type * from './types.utils'


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-rc/#support-for-export-type