### PR TITLE
fix(types): unknown property accessKey in createClient

### DIFF
--- a/packages/clients/src/scw/__tests__/api.test.ts
+++ b/packages/clients/src/scw/__tests__/api.test.ts
@@ -3,13 +3,19 @@ import { API } from '../api'
 import { createClient } from '../client'
 
 class CustomAPI extends API {
-  getBaseURL = (): string => this.client.settings.apiURL
+  getBaseURL = (): string => {
+    if (!this.client.settings.apiURL) {
+      throw new Error('API URL is missing')
+    }
+
+    return this.client.settings.apiURL
+  }
 }
 
 describe('API', () => {
   it('binds methods properly', () => {
     const api = new CustomAPI(createClient())
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+     
     const unboundMethod = api.getBaseURL
     expect(() => {
       unboundMethod()

--- a/packages/clients/src/scw/__tests__/client-ini-factory.test.ts
+++ b/packages/clients/src/scw/__tests__/client-ini-factory.test.ts
@@ -169,6 +169,9 @@ describe('withProfile', () => {
   })
 
   it('modifies authentication', async () => {
+    if (!DEFAULT_SETTINGS.apiURL) {
+      throw new Error('API URL is missing')
+    }
     const request = new Request(DEFAULT_SETTINGS.apiURL)
     const reqInterceptor = withProfile({
       accessKey: FILLED_PROFILE.accessKey,

--- a/packages/clients/src/scw/client-settings.ts
+++ b/packages/clients/src/scw/client-settings.ts
@@ -112,11 +112,11 @@ export const assertValidSettings = (obj: Readonly<Settings>): void => {
   }
 
   // API URL.
-  if (!isURL(obj.apiURL)) {
+  if (obj.apiURL && !isURL(obj.apiURL)) {
     throw new Error(`Invalid URL ${obj.apiURL}`)
   }
 
-  if (obj.apiURL.endsWith('/')) {
+  if (obj.apiURL?.endsWith('/')) {
     throw new Error(
       `Invalid URL ${obj.apiURL}: it should not have a trailing slash`,
     )

--- a/packages/clients/src/scw/client-settings.ts
+++ b/packages/clients/src/scw/client-settings.ts
@@ -10,14 +10,14 @@ import {
   isURL,
   isZone,
 } from '../internal/validations/string-validation'
-import type { ProfileDefaultValues } from './client-ini-profile'
+import type { Profile } from './client-ini-profile'
 
 /**
  * Holds default values of settings.
  *
  * @public
  */
-export type DefaultValues = ProfileDefaultValues & {
+export type DefaultValues = Profile & {
   /**
    * The default number of results when requesting a paginated resource.
    */


### PR DESCRIPTION
The `createClient()` method is using `Partial<Settings>` type, extending `DefaultValues` that was using `ProfileDefaultValues` type. This last type lacked the `accessKey` and `secretKey` properties.

`DefaultValues` type is now inheriting `Profile` type, which contains the correct properties.

fixes #1752