### PR TITLE
fix(release): use pnpm to publish to npm

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -33,7 +33,14 @@ jobs:
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm lerna publish -y --create-release github
+      - name: Version package with lerna
+        run: pnpm run release:version
         env:
           HUSKY: 0
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Push version and tags
+        run: git push origin HEAD:main --follow-tags
+
+      - name: Publish to npm
+        run: pnpm run release:publish

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ coverage
 # Protobuf definition
 protobuf
 .bufcache
+
+#lerna
+lerna-debug.log

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "format": "biome check  --linter-enabled=false --write .",
     "format:check": "biome check --linter-enabled=false --verbose .",
     "prettier": "prettier --write '**/*.{md,mdx,yml,yaml}'",
+    "release:version": "pnpm lerna version -y --create-release-github",
+    "release:publish": "pnpm -r publish --access public --no-git-checks",
     "lint": "eslint --cache .",
     "prepare": "husky",
     "test": "vitest run",


### PR DESCRIPTION
Recently we add multi package for all product, this changed the way we build le public sdk with workspace of pnpm.
This feature is not well supported by npm, used by lerna to publish on the npm store.

https://github.com/lerna/lerna/issues/3671

https://github.com/scaleway/scaleway-sdk-js/issues/2071