### PR TITLE
fix: convert deprecated rmDirSync recursive to rmSync

### DIFF
--- a/tools/generate-react-queries/src/generate.ts
+++ b/tools/generate-react-queries/src/generate.ts
@@ -64,7 +64,7 @@ export async function generateFromMetadata(
         )
 
         if (existsSync(generatedDir)) {
-          rmSync(generatedDir, { recursive: true })
+          rmSync(generatedDir, { recursive: true, force: true })
         }
         mkdirSync(generatedDir, { recursive: true })
 

--- a/tools/generate-react-sdk/src/generateAPI/generate.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generate.ts
@@ -1,5 +1,5 @@
 import { exec } from 'node:child_process'
-import { existsSync, readFileSync, rmdirSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { exit, stdout } from 'node:process'
 import { project } from './config.ts'
@@ -37,8 +37,9 @@ export const generateAPI = ({
   const dir = join(directoryOfSrcFolder, dirGenName)
 
   if (existsSync(dir)) {
-    rmdirSync(dir, {
+    rmSync(dir, {
       recursive: true,
+      force: true
     })
   }
 


### PR DESCRIPTION
rmDirSync recursive has been deprecated since node 14 and removed in node 25