### PR TITLE
fix(chore): release workflow dirty-tree failure before Lerna versioning

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -50,7 +50,15 @@ jobs:
       # need to build tools and install to make tools bin(s) available
       - run: pnpm turbo build "--filter=./tools/*"
       - run: pnpm install
-      - run: pnpm run build
+      - run: pnpm run build:packages
+
+      - name: Ensure working tree is clean before release
+        run: |
+          if [ -n "$(git status --porcelain --untracked-files=normal)" ]; then
+            echo "Release must run from a clean working tree."
+            git status --short
+            exit 1
+          fi
 
       - name: Version package with lerna
         run: pnpm lerna version -y --no-private --force-git-tag --create-release github


### PR DESCRIPTION
## Problem
The release workflow fails with `lerna ERR! EUNCOMMIT` because the git working tree is modified before `lerna version` runs.

## Root cause
The workflow used `pnpm run build`, which is not a read-only validation build in this repository. It triggers generation/formatting steps that can rewrite tracked files (for example changelogs and generated metadata/config files), making the worktree dirty.

## Why this is risky
`lerna version` requires a clean working tree. When release preparation mutates tracked files, versioning fails unpredictably depending on generation state.

## Fix in this PR
- replace `pnpm run build` with `pnpm run build:packages` in the release workflow
- add an explicit clean-worktree guard before `lerna version`:
  - print `git status --short`
  - fail fast if any tracked/untracked changes are present

## Outcome
The release job still validates package builds, while generation responsibilities stay in upstream protobuf/update pipelines. Release remains deterministic and compatible with Lerna versioning requirements.

## Test plan
- [x] Validate workflow diff and command flow
- [ ] Run `Deploy to NPM` on this branch and confirm it reaches `lerna version` without `EUNCOMMIT`