### PR TITLE
feat(tools): add JSON config file support and skip filters

### DIFF
--- a/tools/generate-react-queries/src/cli.ts
+++ b/tools/generate-react-queries/src/cli.ts
@@ -20,63 +20,26 @@ import { generateFromMetadata } from './generate.ts'
 import { updatePackageJsonExports } from './package-exports.ts'
 
 /** Shape of a JSON config file (customNamespaces is [string,string][] here, not a Map). */
-type FileConfig = {
-  outputDir?: string
-  generatedPath?: string
-  customPath?: string
-  packagesPath?: string
+type FileConfig = Omit<ReactQueriesConfig, 'customNamespaces'> & {
   customNamespaces?: [string, string][]
-  imports?: Partial<ReactQueriesConfig['imports']>
-  filters?: Partial<ReactQueriesConfig['filters']>
 }
 
-const TOP_LEVEL_STRING_FIELDS = ['outputDir', 'generatedPath', 'customPath', 'packagesPath'] as const
-const IMPORT_STRING_FIELDS = ['apiSdkPath', 'packageNameFilter', 'dataLoaderPackage'] as const
-const FILTER_ARRAY_FIELDS = ['skipMethods', 'skipPackages', 'skipServices', 'skipVersions', 'rawTypes'] as const
-const FILTER_BOOLEAN_FIELDS = ['skipPrivateMethods', 'skipCursorAllHooks', 'skipWaiters'] as const
-
-/**
- * Merge a JSON config file into the given config. Fields present and valid in
- * the file override the config; anything else is left untouched.
- */
+/** Merge a JSON config file into the given config. File fields override defaults. */
 const loadConfigFile = (config: ReactQueriesConfig, path?: string): ReactQueriesConfig => {
   const fileConfig = loadJsonConfig<FileConfig>(path)
   if (!fileConfig) return config
 
-  const next: ReactQueriesConfig = { ...config }
+  const { customNamespaces, ...rest } = fileConfig
 
-  for (const key of TOP_LEVEL_STRING_FIELDS) {
-    if (typeof fileConfig[key] === 'string') next[key] = fileConfig[key] as string
+  return {
+    ...config,
+    ...rest,
+    imports: { ...config.imports, ...rest.imports },
+    filters: { ...config.filters, ...rest.filters },
+    customNamespaces: Array.isArray(customNamespaces)
+      ? new Map(customNamespaces)
+      : config.customNamespaces,
   }
-
-  if (fileConfig.imports) {
-    const imports = fileConfig.imports
-    for (const key of IMPORT_STRING_FIELDS) {
-      if (typeof imports[key] === 'string') next.imports[key] = imports[key] as string
-    }
-  }
-
-  if (fileConfig.filters) {
-    const filters = fileConfig.filters
-    next.filters = { ...config.filters }
-    for (const key of FILTER_ARRAY_FIELDS) {
-      if (Array.isArray(filters[key])) next.filters[key] = filters[key] as string[]
-    }
-    for (const key of FILTER_BOOLEAN_FIELDS) {
-      if (typeof filters[key] === 'boolean') next.filters[key] = filters[key] as boolean
-    }
-  }
-
-  if (Array.isArray(fileConfig.customNamespaces)) {
-    next.customNamespaces = new Map(
-      fileConfig.customNamespaces.filter(
-        (entry): entry is [string, string] =>
-          Array.isArray(entry) && entry.length === 2 && entry.every(v => typeof v === 'string'),
-      ),
-    )
-  }
-
-  return next
 }
 
 // Parse CLI flags — all optional, defaults come from config.ts

--- a/tools/generate-react-queries/src/cli.ts
+++ b/tools/generate-react-queries/src/cli.ts
@@ -6,41 +6,14 @@
  * Reads metadata.gen.ts from each SDK package's dist/, then generates
  * useQuery / useInfiniteQuery / useReload hooks into sdk-react-hooks.
  *
- * Usage: pnpm generate-react-queries [--config config.json] [--packages-path ../../packages_generated]
- *
- * A JSON config file may override any default from config.ts. Top-level
- * string fields, imports.*, filters.* (arrays/booleans), and customNamespaces
- * (as [string, string][]) are recognised.
+ * Usage: pnpm generate-react-queries [--packages-path ../../packages_generated]
  */
 
 import { parseArgs } from 'node:util'
-import { defaultConfig, loadJsonConfig } from './config.ts'
+import { defaultConfig } from './config.ts'
 import type { ReactQueriesConfig } from './config.ts'
 import { generateFromMetadata } from './generate.ts'
 import { updatePackageJsonExports } from './package-exports.ts'
-
-/** Shape of a JSON config file (customNamespaces is [string,string][] here, not a Map). */
-type FileConfig = Omit<ReactQueriesConfig, 'customNamespaces'> & {
-  customNamespaces?: [string, string][]
-}
-
-/** Merge a JSON config file into the given config. File fields override defaults. */
-const loadConfigFile = (config: ReactQueriesConfig, path?: string): ReactQueriesConfig => {
-  const fileConfig = loadJsonConfig<FileConfig>(path)
-  if (!fileConfig) return config
-
-  const { customNamespaces, ...rest } = fileConfig
-
-  return {
-    ...config,
-    ...rest,
-    imports: { ...config.imports, ...rest.imports },
-    filters: { ...config.filters, ...rest.filters },
-    customNamespaces: Array.isArray(customNamespaces)
-      ? new Map(customNamespaces)
-      : config.customNamespaces,
-  }
-}
 
 // Parse CLI flags — all optional, defaults come from config.ts
 const { values } = parseArgs({
@@ -51,20 +24,22 @@ const { values } = parseArgs({
     'api-sdk-path': { type: 'string' },
     'package-name-filter': { type: 'string' },
     'packages-path': { type: 'string' },
-    'config': { type: 'string' },
+    'skip-services': { type: 'string', multiple: true },
+    'skip-versions': { type: 'string', multiple: true },
   },
   strict: false,
-}) as { values: Record<string, string | undefined> }
+}) as { values: Record<string, string | string[] | undefined> }
 
-// Start from defaults, then apply a config file, then CLI overrides
-const config = loadConfigFile(structuredClone(defaultConfig), values['config'])
+const config: ReactQueriesConfig = structuredClone(defaultConfig)
 
-if (values['dir-gen-name']) config.outputDir = values['dir-gen-name']
-if (values['generated-path']) config.generatedPath = values['generated-path']
-if (values['custom-path']) config.customPath = values['custom-path']
-if (values['api-sdk-path']) config.imports.apiSdkPath = values['api-sdk-path']
-if (values['package-name-filter']) config.imports.packageNameFilter = values['package-name-filter']
-if (values['packages-path']) config.packagesPath = values['packages-path']
+if (typeof values['dir-gen-name'] === 'string') config.outputDir = values['dir-gen-name']
+if (typeof values['generated-path'] === 'string') config.generatedPath = values['generated-path']
+if (typeof values['custom-path'] === 'string') config.customPath = values['custom-path']
+if (typeof values['api-sdk-path'] === 'string') config.imports.apiSdkPath = values['api-sdk-path']
+if (typeof values['package-name-filter'] === 'string') config.imports.packageNameFilter = values['package-name-filter']
+if (typeof values['packages-path'] === 'string') config.packagesPath = values['packages-path']
+if (Array.isArray(values['skip-services'])) config.filters.skipServices = values['skip-services']
+if (Array.isArray(values['skip-versions'])) config.filters.skipVersions = values['skip-versions']
 
 console.log('🚀 Generating React hooks from metadata...')
 console.log('⚠️  Prerequisite: Ensure SDK packages are built first')

--- a/tools/generate-react-queries/src/cli.ts
+++ b/tools/generate-react-queries/src/cli.ts
@@ -6,13 +6,78 @@
  * Reads metadata.gen.ts from each SDK package's dist/, then generates
  * useQuery / useInfiniteQuery / useReload hooks into sdk-react-hooks.
  *
- * Usage: pnpm generate-react-queries [--packages-path ../../packages_generated]
+ * Usage: pnpm generate-react-queries [--config config.json] [--packages-path ../../packages_generated]
+ *
+ * A JSON config file may override any default from config.ts. Top-level
+ * string fields, imports.*, filters.* (arrays/booleans), and customNamespaces
+ * (as [string, string][]) are recognised.
  */
 
 import { parseArgs } from 'node:util'
-import { defaultConfig } from './config.ts'
+import { defaultConfig, loadJsonConfig } from './config.ts'
+import type { ReactQueriesConfig } from './config.ts'
 import { generateFromMetadata } from './generate.ts'
 import { updatePackageJsonExports } from './package-exports.ts'
+
+/** Shape of a JSON config file (customNamespaces is [string,string][] here, not a Map). */
+type FileConfig = {
+  outputDir?: string
+  generatedPath?: string
+  customPath?: string
+  packagesPath?: string
+  customNamespaces?: [string, string][]
+  imports?: Partial<ReactQueriesConfig['imports']>
+  filters?: Partial<ReactQueriesConfig['filters']>
+}
+
+const TOP_LEVEL_STRING_FIELDS = ['outputDir', 'generatedPath', 'customPath', 'packagesPath'] as const
+const IMPORT_STRING_FIELDS = ['apiSdkPath', 'packageNameFilter', 'dataLoaderPackage'] as const
+const FILTER_ARRAY_FIELDS = ['skipMethods', 'skipPackages', 'skipServices', 'skipVersions', 'rawTypes'] as const
+const FILTER_BOOLEAN_FIELDS = ['skipPrivateMethods', 'skipCursorAllHooks', 'skipWaiters'] as const
+
+/**
+ * Merge a JSON config file into the given config. Fields present and valid in
+ * the file override the config; anything else is left untouched.
+ */
+const loadConfigFile = (config: ReactQueriesConfig, path?: string): ReactQueriesConfig => {
+  const fileConfig = loadJsonConfig<FileConfig>(path)
+  if (!fileConfig) return config
+
+  const next: ReactQueriesConfig = { ...config }
+
+  for (const key of TOP_LEVEL_STRING_FIELDS) {
+    if (typeof fileConfig[key] === 'string') next[key] = fileConfig[key] as string
+  }
+
+  if (fileConfig.imports) {
+    const imports = fileConfig.imports
+    for (const key of IMPORT_STRING_FIELDS) {
+      if (typeof imports[key] === 'string') next.imports[key] = imports[key] as string
+    }
+  }
+
+  if (fileConfig.filters) {
+    const filters = fileConfig.filters
+    next.filters = { ...config.filters }
+    for (const key of FILTER_ARRAY_FIELDS) {
+      if (Array.isArray(filters[key])) next.filters[key] = filters[key] as string[]
+    }
+    for (const key of FILTER_BOOLEAN_FIELDS) {
+      if (typeof filters[key] === 'boolean') next.filters[key] = filters[key] as boolean
+    }
+  }
+
+  if (Array.isArray(fileConfig.customNamespaces)) {
+    next.customNamespaces = new Map(
+      fileConfig.customNamespaces.filter(
+        (entry): entry is [string, string] =>
+          Array.isArray(entry) && entry.length === 2 && entry.every(v => typeof v === 'string'),
+      ),
+    )
+  }
+
+  return next
+}
 
 // Parse CLI flags — all optional, defaults come from config.ts
 const { values } = parseArgs({
@@ -23,12 +88,13 @@ const { values } = parseArgs({
     'api-sdk-path': { type: 'string' },
     'package-name-filter': { type: 'string' },
     'packages-path': { type: 'string' },
+    'config': { type: 'string' },
   },
   strict: false,
 }) as { values: Record<string, string | undefined> }
 
-// Override defaults with any CLI-provided values
-const config = structuredClone(defaultConfig)
+// Start from defaults, then apply a config file, then CLI overrides
+const config = loadConfigFile(structuredClone(defaultConfig), values['config'])
 
 if (values['dir-gen-name']) config.outputDir = values['dir-gen-name']
 if (values['generated-path']) config.generatedPath = values['generated-path']

--- a/tools/generate-react-queries/src/config.ts
+++ b/tools/generate-react-queries/src/config.ts
@@ -5,8 +5,6 @@
  * Config controls naming conventions, filtering, and import paths.
  */
 
-import { existsSync, readFileSync } from 'node:fs'
-
 // --- Types (mirror metadata.gen.ts structure in each SDK package) ---
 
 /** A single API method that will become a React Query hook. */
@@ -149,24 +147,4 @@ export function capitalize(str: string): string {
 export function lowerCaseFirst(str: string): string {
   if (!str) return str
   return str.charAt(0).toLowerCase() + str.slice(1)
-}
-
-// --- Config helpers ---
-
-/**
- * Load and parse a JSON config file, returning undefined (with a warning) if
- * the file is missing or malformed.
- */
-export function loadJsonConfig<T>(path?: string): T | undefined {
-  if (!path) return undefined
-  if (!existsSync(path)) {
-    console.warn(`⚠️  Config file not found: ${path} (ignored)`)
-    return undefined
-  }
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as T
-  } catch (error) {
-    console.warn(`⚠️  Could not parse config file ${path}: ${error}`)
-    return undefined
-  }
 }

--- a/tools/generate-react-queries/src/config.ts
+++ b/tools/generate-react-queries/src/config.ts
@@ -5,6 +5,8 @@
  * Config controls naming conventions, filtering, and import paths.
  */
 
+import { existsSync, readFileSync } from 'node:fs'
+
 // --- Types (mirror metadata.gen.ts structure in each SDK package) ---
 
 /** A single API method that will become a React Query hook. */
@@ -86,6 +88,13 @@ export interface ReactQueriesConfig {
     skipWaiters: boolean
     /** Package names to exclude from generation (e.g. @scaleway/sdk-test). */
     skipPackages: string[]
+    /** Service classes to exclude (matched against service.apiClass). */
+    skipServices: string[]
+    /**
+     * Versions to exclude. "<package>@<version>" skips only that package's
+     * version; a bare "<version>" skips it for all packages.
+     */
+    skipVersions: string[]
   }
 
   generatedComment: string
@@ -122,6 +131,8 @@ export const defaultConfig: ReactQueriesConfig = {
     skipWaiters: true,
     rawTypes: ['Blob', 'string', 'number', 'boolean'],
     skipPackages: ['@scaleway/sdk-test'],
+    skipServices: [],
+    skipVersions: [],
   },
 
   generatedComment:
@@ -138,4 +149,24 @@ export function capitalize(str: string): string {
 export function lowerCaseFirst(str: string): string {
   if (!str) return str
   return str.charAt(0).toLowerCase() + str.slice(1)
+}
+
+// --- Config helpers ---
+
+/**
+ * Load and parse a JSON config file, returning undefined (with a warning) if
+ * the file is missing or malformed.
+ */
+export function loadJsonConfig<T>(path?: string): T | undefined {
+  if (!path) return undefined
+  if (!existsSync(path)) {
+    console.warn(`⚠️  Config file not found: ${path} (ignored)`)
+    return undefined
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T
+  } catch (error) {
+    console.warn(`⚠️  Could not parse config file ${path}: ${error}`)
+    return undefined
+  }
 }

--- a/tools/generate-react-queries/src/generate.ts
+++ b/tools/generate-react-queries/src/generate.ts
@@ -18,9 +18,14 @@ import {
 export async function generateFromMetadata(config: ReactQueriesConfig): Promise<void> {
   const sdkPackages = discoverSdkPackages(config)
   const skipMethods = new Set(config.filters.skipMethods)
+  const skipServices = new Set(config.filters.skipServices)
+  const skipVersions = new Set(config.filters.skipVersions)
   const { metadataFileName } = config.naming
 
   const skipPackages = new Set(config.filters.skipPackages)
+
+  const isVersionSkipped = (packageName: string, version: string): boolean =>
+    skipVersions.has(`${packageName}@${version}`) || skipVersions.has(version)
 
   for (const [packageName, pkgDir] of sdkPackages) {
     if (skipPackages.has(packageName)) {
@@ -38,6 +43,11 @@ export async function generateFromMetadata(config: ReactQueriesConfig): Promise<
     console.log(`  📦 ${packageName}: ${versions.length} version(s): ${versions.join(', ')}`)
 
     for (const version of versions) {
+      if (isVersionSkipped(packageName, version)) {
+        console.log(`  ⏭️  Skipping ${packageName}/${version} (excluded by skipVersions)`)
+        continue
+      }
+
       try {
         const metadata = await loadMetadata(pkgDir, version, metadataFileName)
 
@@ -54,7 +64,16 @@ export async function generateFromMetadata(config: ReactQueriesConfig): Promise<
         }
         mkdirSync(generatedDir, { recursive: true })
 
-        for (const service of services) {
+        const servicesToGenerate = services.filter(
+          service => !skipServices.has(service.apiClass),
+        )
+
+        if (servicesToGenerate.length === 0) {
+          console.log(` ⏭️  Skipping ${packageName}/${version}: all services excluded by skipServices`)
+          continue
+        }
+
+        for (const service of servicesToGenerate) {
           console.log(`📝 Generating hooks for ${service.apiClass}`)
 
           for (const method of service.methods) {
@@ -98,7 +117,7 @@ export async function generateFromMetadata(config: ReactQueriesConfig): Promise<
         }
 
         // Barrel file re-exporting all generated hooks for this namespace
-        const indexContent = generateIndexFile(services, metadata, config)
+        const indexContent = generateIndexFile(servicesToGenerate, metadata, config)
         writeFileSync(join(generatedDir, config.naming.indexFile), indexContent)
 
         console.log(`✅ Generated hooks for ${folderName}`)

--- a/tools/generate-react-sdk/src/buildAPI.ts
+++ b/tools/generate-react-sdk/src/buildAPI.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+import { existsSync, readFileSync } from 'node:fs'
 import { generateAPI } from './generateAPI/index.ts'
 import { parseArgsCLI } from './parseArgsCLI.ts'
 
-const requiresValueArgs = ['dir-gen-name', 'sdk-factory-path', 'package-name-filter']
+const requiresValueArgs = ['dir-gen-name', 'sdk-factory-path', 'package-name-filter', 'config']
 // Parse CLI arguments
 const { cliArgs } = parseArgsCLI({ requiresValueArgs })
 
@@ -13,10 +14,40 @@ const sdkFactoryPath = (cliArgs['sdk-factory-path'] as string | undefined) || '.
 
 const packageNameFilter = (cliArgs['package-name-filter'] as string | undefined) || '@scaleway/sdk-'
 
+type ConfigFile = {
+  filters?: {
+    skipServices?: string[]
+    skipVersions?: string[]
+  }
+}
+
+/** Load and parse a JSON config file, returning undefined (with a warning) if missing or malformed. */
+const loadJsonConfig = <T>(path?: string): T | undefined => {
+  if (!path) return undefined
+  if (!existsSync(path)) {
+    console.warn(`⚠️  Config file not found: ${path} (ignored)`)
+    return undefined
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T
+  } catch (error) {
+    console.warn(`⚠️  Could not parse config file ${path}: ${error}`)
+    return undefined
+  }
+}
+
+const fileConfig = loadJsonConfig<ConfigFile>(
+  typeof cliArgs['config'] === 'string' ? cliArgs['config'] : undefined,
+)
+const skipServices = fileConfig?.filters?.skipServices ?? []
+const skipVersions = fileConfig?.filters?.skipVersions ?? []
+
 await generateAPI({
   dirGenName,
   sdkFactoryPath,
   packageNameFilter,
+  skipServices,
+  skipVersions,
 })
 
 process.stdout.write('✅ generateAPI !')

--- a/tools/generate-react-sdk/src/buildAPI.ts
+++ b/tools/generate-react-sdk/src/buildAPI.ts
@@ -1,46 +1,28 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync } from 'node:fs'
+import { parseArgs } from 'node:util'
 import { generateAPI } from './generateAPI/index.ts'
-import { parseArgsCLI } from './parseArgsCLI.ts'
 
-const requiresValueArgs = ['dir-gen-name', 'sdk-factory-path', 'package-name-filter', 'config']
 // Parse CLI arguments
-const { cliArgs } = parseArgsCLI({ requiresValueArgs })
+const { values } = parseArgs({
+  options: {
+    'dir-gen-name': { type: 'string' },
+    'sdk-factory-path': { type: 'string' },
+    'package-name-filter': { type: 'string' },
+    'skip-services': { type: 'string', multiple: true },
+    'skip-versions': { type: 'string', multiple: true },
+  },
+  strict: false,
+}) as { values: Record<string, string | string[] | undefined> }
 
-const dirGenName = (cliArgs['dir-gen-name'] as string | undefined) || 'src/__generated__'
+const dirGenName = (values['dir-gen-name'] as string | undefined) || 'src/__generated__'
 
-const sdkFactoryPath = (cliArgs['sdk-factory-path'] as string | undefined) || '../contexts/SDKCacheProvider/sdkFactory'
+const sdkFactoryPath = (values['sdk-factory-path'] as string | undefined) || '../contexts/SDKCacheProvider/sdkFactory'
 
-const packageNameFilter = (cliArgs['package-name-filter'] as string | undefined) || '@scaleway/sdk-'
+const packageNameFilter = (values['package-name-filter'] as string | undefined) || '@scaleway/sdk-'
 
-type ConfigFile = {
-  filters?: {
-    skipServices?: string[]
-    skipVersions?: string[]
-  }
-}
-
-/** Load and parse a JSON config file, returning undefined (with a warning) if missing or malformed. */
-const loadJsonConfig = <T>(path?: string): T | undefined => {
-  if (!path) return undefined
-  if (!existsSync(path)) {
-    console.warn(`⚠️  Config file not found: ${path} (ignored)`)
-    return undefined
-  }
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as T
-  } catch (error) {
-    console.warn(`⚠️  Could not parse config file ${path}: ${error}`)
-    return undefined
-  }
-}
-
-const fileConfig = loadJsonConfig<ConfigFile>(
-  typeof cliArgs['config'] === 'string' ? cliArgs['config'] : undefined,
-)
-const skipServices = fileConfig?.filters?.skipServices ?? []
-const skipVersions = fileConfig?.filters?.skipVersions ?? []
+const skipServices = Array.isArray(values['skip-services']) ? values['skip-services'] : []
+const skipVersions = Array.isArray(values['skip-versions']) ? values['skip-versions'] : []
 
 await generateAPI({
   dirGenName,

--- a/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
@@ -71,10 +71,14 @@ export const generateAPI = async ({
   dirGenName,
   sdkFactoryPath,
   packageNameFilter,
+  skipServices = [],
+  skipVersions = [],
 }: {
   dirGenName: string
   sdkFactoryPath: string
   packageNameFilter: string
+  skipServices?: string[]
+  skipVersions?: string[]
 }) => {
   let result: ProcessedMetadata = {}
 
@@ -90,6 +94,11 @@ export const generateAPI = async ({
   }
 
   const skipPackages = new Set(['@scaleway/sdk-test', '@scaleway/sdk-std'])
+  const servicesToSkip = new Set(skipServices)
+  const versionsToSkip = new Set(skipVersions)
+
+  const isVersionSkipped = (packageName: string, version: string): boolean =>
+    versionsToSkip.has(`${packageName}@${version}`) || versionsToSkip.has(version)
 
   for (const [packageName] of sdkPackages) {
     if (skipPackages.has(packageName)) {
@@ -105,6 +114,11 @@ export const generateAPI = async ({
     }
 
     for (const version of versions) {
+      if (isVersionSkipped(packageName, version)) {
+        stdout.write(`⚠️  Skipping ${packageName}/${version}: excluded by skipVersions\n`)
+        continue
+      }
+
       const metadata = await loadMetadata(packageName, version)
 
       if (!metadata) {
@@ -114,6 +128,7 @@ export const generateAPI = async ({
 
       const namespace = metadata.folderName || metadata.namespace
       const apis = metadata.services
+        .filter((service: { apiClass: string }) => !servicesToSkip.has(service.apiClass))
         .map((service: { apiClass: string }) => service.apiClass)
         .filter((apiClass: string) => apiClass && apiClass.length > 0)
 


### PR DESCRIPTION
- Added `--config` flag to load JSON config that overrides defaults in both `generate-react-queries` and `generate-react-sdk`
- Introduced `loadJsonConfig` helper to parse and validate config files with graceful error handling
- Added `skipServices` and `skipVersions` filters to exclude specific services and package versions from generation
- update the readme. 