### PR TITLE
feat(sdk-react): expose ClientContext

### DIFF
--- a/packages/sdk-react/src/contexts/SDKCacheProvider/SDKCacheProvider.tsx
+++ b/packages/sdk-react/src/contexts/SDKCacheProvider/SDKCacheProvider.tsx
@@ -28,10 +28,13 @@ export const useSDKCache = <TCustomAPIs extends DefaultTypeBaseAPI = DefaultType
   }
 }
 
-export const SDKCacheProvider = ({ children }: PropsWithChildren) => {
+export const SDKCacheProvider = ({
+  children,
+  initialCache = null,
+}: PropsWithChildren<{ initialCache?: APISdkCache | null }>) => {
   const { client } = useClient()
 
-  const [sdkCache, setSdkCache] = useState<APISdkCache | null>(null)
+  const [sdkCache, setSdkCache] = useState<APISdkCache | null>(initialCache)
 
   const setSdkInstance = useCallback(
     (sdkInstance: Partial<APISdkCache>) => {

--- a/packages/sdk-react/src/contexts/SDKCacheProvider/sdkFactory.ts
+++ b/packages/sdk-react/src/contexts/SDKCacheProvider/sdkFactory.ts
@@ -1,12 +1,13 @@
 import type { Client } from '@scaleway/sdk-client'
-import { useClient } from '../ClientProvider'
+import { useContext } from 'react'
+import { ClientContext, useClient } from '../ClientProvider'
 import type { APISdkCache, DefaultTypeBaseAPI, ExtendedAPISdkCache } from '../types'
 import { useSDKCache } from './SDKCacheProvider'
 
 export const createSDKFactory =
   <K extends keyof APISdkCache>(SDKNamespace: { new (client: Client): APISdkCache[K] }, cacheKey: K) =>
   () => {
-    const { client } = useClient()
+    const clientCtx = useContext(ClientContext)
     const { sdkCache, setSdkInstance } = useSDKCache()
 
     // Check if we already have this SDK instance cached
@@ -14,8 +15,14 @@ export const createSDKFactory =
       return { [cacheKey]: sdkCache[cacheKey] } as { [P in K]: APISdkCache[P] }
     }
 
+    if (!clientCtx) {
+      if (!clientCtx) {
+        throw new Error('Missing ClientContext, make sure you have a ClientProvider')
+      }
+    }
+
     // Create new instance using the provided factory function
-    const instance = new SDKNamespace(client)
+    const instance = new SDKNamespace(clientCtx.client)
 
     // Cache the instance
     setSdkInstance({ [cacheKey]: instance })

--- a/packages/sdk-react/src/index.ts
+++ b/packages/sdk-react/src/index.ts
@@ -1,4 +1,4 @@
 export { APIProvider } from './contexts/APIProvider'
-export { useClient } from './contexts/ClientProvider'
+export { useClient, ClientContext } from './contexts/ClientProvider'
 export { createGenericSDKFactory, createSDKFactory, SDKCacheProvider, useSDKCache } from './contexts/SDKCacheProvider'
 export type { APISdkCache, BaseAPISdkCache, ExtendedAPISdkCache } from './contexts/types'


### PR DESCRIPTION
Expose ClientContext from `sdk-react`.
Additionally I changed a bit createSDKFactory so that it fails when ClientContext is missing only when trying to initialize a SDK. This mean that if we provide a sdk cache with all SDKs we can skip the ClientProvider entirely (useful for mocking use cases).