### PR TITLE
fix(client): prevent logRequest from consuming the request body

### DIFF
--- a/packages/client/src/scw/fetch/__tests__/http-interceptors.test.ts
+++ b/packages/client/src/scw/fetch/__tests__/http-interceptors.test.ts
@@ -46,6 +46,21 @@ describe(`logRequest`, () => {
     await logRequest('1')({ request })
     expect(latestMessage.startsWith('--------------- Scaleway SDK REQUEST 1')).toBe(true)
   })
+
+  it(`does not consume the original request body`, async () => {
+    enableDummyLogger('debug')
+    const requestWithBody = new Request('https://api.scaleway.com', {
+      method: 'POST',
+      body: 'hello-world',
+    })
+    await logRequest(
+      '1',
+      obfuscateInterceptor(([name, value]) => [name, value]),
+    )({
+      request: requestWithBody,
+    })
+    expect(await requestWithBody.clone().text()).toBe('hello-world')
+  })
 })
 
 describe(`logResponse`, () => {

--- a/packages/client/src/scw/fetch/http-interceptors.ts
+++ b/packages/client/src/scw/fetch/http-interceptors.ts
@@ -25,18 +25,18 @@ type HeaderEntryMapper = (entry: [string, string]) => [string, string]
  */
 class ObfuscatedRequest extends Request {
   constructor(
-    private request: Request,
+    request: Request,
     private obfuscate: HeaderEntryMapper,
   ) {
-    super(request)
+    super(request.clone())
   }
 
   get headers() {
-    return new Headers(Array.from(this.request.headers, this.obfuscate))
+    return new Headers(Array.from(super.clone().headers, this.obfuscate))
   }
 
   clone(): ObfuscatedRequest {
-    return new ObfuscatedRequest(this.request, this.obfuscate)
+    return new ObfuscatedRequest(super.clone(), this.obfuscate)
   }
 }
 


### PR DESCRIPTION
Constructing a Request from another Request locks the source body
stream per the Fetch spec. ObfuscatedRequest now clones its source
before calling super(), so the original request returned by logRequest
stays usable for the real network call.

This only affected requests with a body (POST/PUT/PATCH/DELETE) at
debug log level, since that is the only path that builds an
ObfuscatedRequest for dumping.