### PR TITLE
feat(client): add AbortSignal / request cancellation support

### DIFF
--- a/packages/client/src/internal/async/__tests__/interval-retrier.test.ts
+++ b/packages/client/src/internal/async/__tests__/interval-retrier.test.ts
@@ -117,6 +117,21 @@ describe('tryAtIntervals', () => {
     const result = await tryAtIntervals(mLogic, zeroIntervalStrat)
     expect(result.doneIterations).toBe(3)
   })
+
+  it('throws an AbortError when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    await expect(tryAtIntervals(mockLogic(3, 0), zeroIntervalStrat, 1, controller.signal)).rejects.toThrow(
+      'The operation was aborted',
+    )
+  })
+
+  it('throws an AbortError when the signal aborts mid-loop', async () => {
+    const controller = new AbortController()
+    const result = tryAtIntervals(mockLogic(10, 0), zeroIntervalStrat, 5, controller.signal)
+    controller.abort()
+    await expect(result).rejects.toThrow('The operation was aborted')
+  })
 })
 
 describe('waitForResource', () => {
@@ -151,5 +166,18 @@ describe('waitForResource', () => {
     )
 
     return expect(result).rejects.toThrow()
+  })
+
+  it('rejects with AbortError when the signal is aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const result = waitForResource(
+      res => Promise.resolve(!['transient-one', 'transient-two'].includes(res.status)),
+      () => Promise.resolve({ message: 'Still processing.', status: 'transient-two' }),
+      { resourceId: 'random-uuid' },
+      { maxDelay: 1, minDelay: 1, signal: controller.signal },
+    )
+
+    await expect(result).rejects.toThrow('The operation was aborted')
   })
 })

--- a/packages/client/src/internal/async/interval-retrier.ts
+++ b/packages/client/src/internal/async/interval-retrier.ts
@@ -1,3 +1,4 @@
+import { AbortError } from '../../scw/fetch/abort-error.js'
 import { sleep } from './sleep.js'
 
 const DEFAULT_TIMEOUT_SECONDS = 300
@@ -87,8 +88,9 @@ export function* createExponentialBackoffStrategy(minDelay: number, maxDelay: nu
  * @param retry - The function to retry logic between each interval
  * @param strategy - A generated interval strategy iterator
  * @param timeout - The maximum time elapsed before timeout error
+ * @param signal - An {@link AbortSignal} to cancel the polling loop
  *
- * @throws An timeout exception or error thrown by the logic being run
+ * @throws An timeout exception, an {@link AbortError} or error thrown by the logic being run
  *
  * @internal
  */
@@ -96,10 +98,12 @@ export const tryAtIntervals = async <T>(
   retry: Retry<T>,
   strategy: IntervalStrategy,
   timeout: number = DEFAULT_TIMEOUT_SECONDS,
+  signal?: AbortSignal,
 ): Promise<T> => {
   const timeoutTimestamp = Date.now() + timeout * 1000
   let retryCount = 0
   while (Date.now() <= timeoutTimestamp) {
+    if (signal?.aborted) throw new AbortError()
     retryCount += 1
     const delay = strategy.next(retryCount).value * 1000
     // Break if timeout has been reached
@@ -151,6 +155,10 @@ export interface WaitForOptions<T> {
    * @defaultValue Waits for non-transient value.
    */
   stop?: WaitForStopCondition<T>
+  /**
+   * An {@link AbortSignal} to cancel the polling loop.
+   */
+  signal?: AbortSignal
 }
 
 type ResourceFetcher<T, R> = (request: R) => Promise<T>
@@ -189,4 +197,5 @@ export const waitForResource = <R, T>(
     },
     strategy,
     options?.timeout,
+    options?.signal,
   )

--- a/packages/client/src/internals.ts
+++ b/packages/client/src/internals.ts
@@ -1,4 +1,6 @@
 export { isJSONObject } from './helpers/json.js'
+export { createExponentialBackoffStrategy, tryAtIntervals, waitForResource } from './internal/async/interval-retrier.js'
+export { AbortError, isAbortError } from './scw/fetch/abort-error.js'
 export {
   resolveOneOf,
   unmarshalArrayOfObject,
@@ -7,7 +9,6 @@ export {
   urlParams,
   validatePathParam,
 } from './helpers/marshalling.js'
-export { createExponentialBackoffStrategy, tryAtIntervals, waitForResource } from './internal/async/interval-retrier.js'
 export { addAsyncHeaderInterceptor } from './internal/interceptors/helpers.js'
 export { API } from './scw/api.js'
 export { authenticateWithSessionToken } from './scw/auth.js'

--- a/packages/client/src/scw/fetch/__tests__/build-fetcher.test.ts
+++ b/packages/client/src/scw/fetch/__tests__/build-fetcher.test.ts
@@ -67,6 +67,14 @@ describe(`buildRequest`, () => {
     const fReq = buildRequest(mReq, DEFAULT_SETTINGS)
     expect(fReq.url).toBe('https://api.scaleway.com/undefined?param1=value1&param2=value2')
   })
+
+  it(`wires the AbortSignal to the Request`, () => {
+    const controller = new AbortController()
+    const fReq = buildRequest({ ...SCW_POST_REQUEST, signal: controller.signal }, DEFAULT_SETTINGS)
+    expect(fReq.signal.aborted).toBe(false)
+    controller.abort()
+    expect(fReq.signal.aborted).toBe(true)
+  })
 })
 
 describe(`buildFetcher (mock)`, () => {

--- a/packages/client/src/scw/fetch/abort-error.ts
+++ b/packages/client/src/scw/fetch/abort-error.ts
@@ -1,0 +1,22 @@
+/**
+ * Error thrown when a request or a polling loop is cancelled via an {@link AbortSignal}.
+ *
+ * @public
+ */
+export class AbortError extends Error {
+  constructor(message = 'The operation was aborted') {
+    super(message)
+    this.name = 'AbortError'
+  }
+}
+
+/**
+ * Returns whether the given error is an {@link AbortError}.
+ *
+ * @param err - The error to check
+ * @returns True if the error is an abort error
+ *
+ * @public
+ */
+export const isAbortError = (err: unknown): err is AbortError =>
+  err instanceof AbortError || (err instanceof Error && err.name === 'AbortError')

--- a/packages/client/src/scw/fetch/build-fetcher.ts
+++ b/packages/client/src/scw/fetch/build-fetcher.ts
@@ -34,6 +34,7 @@ export const buildRequest = (request: Readonly<ScwRequest>, settings: Readonly<S
       ...request.headers,
     },
     method: request.method,
+    signal: request.signal,
   })
 }
 

--- a/packages/client/src/scw/fetch/types.ts
+++ b/packages/client/src/scw/fetch/types.ts
@@ -6,6 +6,8 @@ export interface ScwRequest {
   body?: string
   urlParams?: URLSearchParams
   responseType?: 'json' | 'text' | 'blob'
+  /** An {@link AbortSignal} to cancel the request. */
+  signal?: AbortSignal
 }
 
 /**


### PR DESCRIPTION
## Description

Closes #3312

Adds request cancellation support throughout the SDK so in-flight requests and long `waitFor*` polling loops can be aborted via an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).

A `grep` for `AbortController|AbortSignal|signal` in `packages/client/src` previously returned nothing.

### Changes

- **`ScwRequest.signal?: AbortSignal`** (`packages/client/src/scw/fetch/types.ts`)
- **`buildRequest`** now attaches `request.signal` to the outgoing `Request` (`packages/client/src/scw/fetch/build-fetcher.ts`)
- **`tryAtIntervals`** accepts an `AbortSignal` and throws an `AbortError` at the top of each loop iteration when the signal is aborted (`packages/client/src/internal/async/interval-retrier.ts`)
- **`WaitForOptions.signal`** plumbed through `waitForResource` — so the generated `waitFor*` helpers gain cancellation for free, since they pass `options` straight through
- **`AbortError` + `isAbortError`** helper (`packages/client/src/scw/fetch/abort-error.ts`), exported from `@scaleway/sdk-client`

### Motivation

- React `useEffect` cleanup (cancel stale requests / watchers)
- Interruptible long `waitFor*` loops
- Serverless functions that must respect an invocation deadline

### Tests

Added coverage for:
- cancellation of a polling loop (pre-aborted and mid-loop) in `tryAtIntervals`
- `waitForResource` rejecting with `AbortError`
- `buildRequest` wiring the signal into the `Request`

All 546 client tests pass; typecheck clean.

### Usage

```ts
import { isAbortError } from '@scaleway/sdk-client'

const controller = new AbortController()

// cancel an in-flight request
const client = createClient({ ... })
client.fetch({ method: 'GET', path: '/...', signal: controller.signal })

// or interrupt a waiter
api.waitForX(request, { signal: controller.signal })

// later
controller.abort()

// distinguish cancellation from a real failure
try {
  await ...
} catch (err) {
  if (isAbortError(err)) { /* cancelled */ }
}
```

> Note: plumbing `signal` into each generated API method's argument is handled on the next `api.gen.ts` regeneration by the external codegen; the core client plumbing this PR adds is the foundation.