### PR TITLE
fix(oxlint): fix typescript/no-unsafe-argument violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
   ],
   rules: {
     "typescript/no-unsafe-member-access": "warn",
-    "typescript/no-unsafe-argument": "warn",
     "typescript/no-unsafe-assignment": "warn",
     "typescript/no-unsafe-return": "warn",
     "typescript/consistent-type-definitions": "warn",

--- a/tools/generate-packages/src/config.ts
+++ b/tools/generate-packages/src/config.ts
@@ -67,7 +67,7 @@ export const loadConfig = async (configPath?: string): Promise<Config> => {
 
   if (!existsSync(resolvedPath)) return resolvePaths(DEFAULT_CONFIG)
 
-  const mod = await import(`file://${resolvedPath}`)
+  const mod = (await import(`file://${resolvedPath}`)) as { default?: Config } & Config
   return resolvePaths(mod.default ?? mod)
 }
 

--- a/tools/generate-react-queries/src/discover.ts
+++ b/tools/generate-react-queries/src/discover.ts
@@ -56,7 +56,7 @@ function discoverFromDirectory(packagesPath: string): Map<string, string> {
     }
 
     try {
-      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as { name?: string }
       if (pkgJson.name) {
         packages.set(pkgJson.name, dirPath)
       }


### PR DESCRIPTION
Fixes all `typescript/no-unsafe-argument` violations and removes the rule from `oxlint.config.ts`.

Closes #3344