### PR TITLE
fix(oxlint): fix eslint/no-continue violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -25,7 +25,6 @@ export default defineConfig({
     'typescript/no-unsafe-return': 'warn',
     'typescript/consistent-type-definitions': 'warn',
     'eslint/no-console': 'warn',
-    'eslint/no-continue': 'warn',
     'eslint/no-unused-vars': 'warn',
     'eslint/max-statements': 'warn',
     'unicorn/catch-error-name': 'warn',

--- a/tools/generate-packages/src/commands/deps.ts
+++ b/tools/generate-packages/src/commands/deps.ts
@@ -61,36 +61,36 @@ export const deps = async ({ src, config, dryRun = false }: DepsOptions): Promis
 
   for (const pkg of packages) {
     const srcDir = join(pkg.path, 'src')
-    if (!existsSync(srcDir)) continue
+    if (existsSync(srcDir)) {
+      const imports = new Set<string>()
+      for (const file of getAllGenTsFiles(srcDir)) {
+        const content = readFileSync(file, 'utf8')
+        importRegex.lastIndex = 0
+        let match: RegExpExecArray | null
+        while ((match = importRegex.exec(content)) !== null) {
+          const pkgName = match[1]?.split('/').slice(0, 2).join('/')
+          if (pkgName && pkgMap.has(pkgName) && pkgName !== pkg.packageJson.name) imports.add(pkgName)
+        }
+      }
 
-    const imports = new Set<string>()
-    for (const file of getAllGenTsFiles(srcDir)) {
-      const content = readFileSync(file, 'utf8')
-      importRegex.lastIndex = 0
-      let match: RegExpExecArray | null
-      while ((match = importRegex.exec(content)) !== null) {
-        const pkgName = match[1]?.split('/').slice(0, 2).join('/')
-        if (pkgName && pkgMap.has(pkgName) && pkgName !== pkg.packageJson.name) imports.add(pkgName)
+      const missing = [...imports].filter(imp => !pkg.packageJson.dependencies?.[imp])
+      if (missing.length > 0) {
+        const allDeps = [
+          ...Object.entries(pkg.packageJson.dependencies ?? {}),
+          ...missing.map(d => [d, 'workspace:*'] as const),
+        ]
+        allDeps.sort(([a], [b]) => a.localeCompare(b))
+        pkg.packageJson.dependencies = Object.fromEntries(allDeps)
+
+        if (dryRun) {
+          console.log(`  🔍 DRY RUN: Would add to ${pkg.name}: ${missing.join(', ')}`)
+        } else {
+          writeFileSync(pkg.packageJsonPath, `${JSON.stringify(pkg.packageJson, null, 2)}\n`, 'utf8')
+          console.log(`  ✅ Updated ${pkg.name}: +${missing.length} deps`)
+        }
+        updated++
       }
     }
-
-    const missing = [...imports].filter(imp => !pkg.packageJson.dependencies?.[imp])
-    if (missing.length === 0) continue
-
-    const allDeps = [
-      ...Object.entries(pkg.packageJson.dependencies ?? {}),
-      ...missing.map(d => [d, 'workspace:*'] as const),
-    ]
-    allDeps.sort(([a], [b]) => a.localeCompare(b))
-    pkg.packageJson.dependencies = Object.fromEntries(allDeps)
-
-    if (dryRun) {
-      console.log(`  🔍 DRY RUN: Would add to ${pkg.name}: ${missing.join(', ')}`)
-    } else {
-      writeFileSync(pkg.packageJsonPath, `${JSON.stringify(pkg.packageJson, null, 2)}\n`, 'utf8')
-      console.log(`  ✅ Updated ${pkg.name}: +${missing.length} deps`)
-    }
-    updated++
   }
 
   console.log(`\n📊 Packages updated: ${updated}`)

--- a/tools/generate-packages/src/commands/packages.ts
+++ b/tools/generate-packages/src/commands/packages.ts
@@ -52,42 +52,42 @@ export const packages = async ({ src: inputPathDir, runInstall = true }: Package
 
   for (const productDir of readdirSync(inputPathDir)) {
     const fullPath = join(inputPathDir, productDir)
-    if (!statSync(fullPath).isDirectory() || CUSTOM.PRODUCT_EXPORT.has(productDir)) continue
-
-    const packageJsonPath = join(fullPath, 'package.json')
-    if (!existsSync(packageJsonPath)) {
-      const pkg = renderTemplatePackageJson(templateString, { name: snakeToSlug(productDir) })
-      writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2))
-    }
-
-    const srcPath = join(fullPath, 'src')
-    const indexGenPath = join(srcPath, 'index.gen.ts')
-    writeFileSync(indexGenPath, AUTO_GENERATE_MESSAGE)
-    for (const versionDir of readdirSync(srcPath)) {
-      if (statSync(join(srcPath, versionDir)).isDirectory()) {
-        const exportPath = CUSTOM.PRODUCT_VERSION_EXPORT.has(`${productDir}/${versionDir}`)
-          ? `./${versionDir}/index.js`
-          : `./${versionDir}/index.gen.js`
-        appendFileSync(indexGenPath, `\nexport * as ${snakeToPascal(productDir)}${versionDir} from '${exportPath}'`)
+    if (statSync(fullPath).isDirectory() && !CUSTOM.PRODUCT_EXPORT.has(productDir)) {
+      const packageJsonPath = join(fullPath, 'package.json')
+      if (!existsSync(packageJsonPath)) {
+        const pkg = renderTemplatePackageJson(templateString, { name: snakeToSlug(productDir) })
+        writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2))
       }
+
+      const srcPath = join(fullPath, 'src')
+      const indexGenPath = join(srcPath, 'index.gen.ts')
+      writeFileSync(indexGenPath, AUTO_GENERATE_MESSAGE)
+      for (const versionDir of readdirSync(srcPath)) {
+        if (statSync(join(srcPath, versionDir)).isDirectory()) {
+          const exportPath = CUSTOM.PRODUCT_VERSION_EXPORT.has(`${productDir}/${versionDir}`)
+            ? `./${versionDir}/index.js`
+            : `./${versionDir}/index.gen.js`
+          appendFileSync(indexGenPath, `\nexport * as ${snakeToPascal(productDir)}${versionDir} from '${exportPath}'`)
+        }
+      }
+
+      const versionsList = readdirSync(srcPath)
+        .filter(d => statSync(join(srcPath, d)).isDirectory())
+        .map(v => `"${v}"`)
+        .join(', ')
+      writeFileSync(
+        join(srcPath, 'metadata.gen.ts'),
+        renderTemplate(metadataTsTemplateString, {
+          name: snakeToSlug(productDir),
+          displayName: snakeToDisplayName(productDir),
+          versions: versionsList,
+        }),
+      )
+
+      copyFileSync(TEMPLATES.TS_CONFIG, join(fullPath, 'tsconfig.json'))
+      copyFileSync(TEMPLATES.TS_CONFIG_BUILD, join(fullPath, 'tsconfig.build.json'))
+      copyFileSync(TEMPLATES.VITE_CONFIG, join(fullPath, 'vite.config.ts'))
     }
-
-    const versionsList = readdirSync(srcPath)
-      .filter(d => statSync(join(srcPath, d)).isDirectory())
-      .map(v => `"${v}"`)
-      .join(', ')
-    writeFileSync(
-      join(srcPath, 'metadata.gen.ts'),
-      renderTemplate(metadataTsTemplateString, {
-        name: snakeToSlug(productDir),
-        displayName: snakeToDisplayName(productDir),
-        versions: versionsList,
-      }),
-    )
-
-    copyFileSync(TEMPLATES.TS_CONFIG, join(fullPath, 'tsconfig.json'))
-    copyFileSync(TEMPLATES.TS_CONFIG_BUILD, join(fullPath, 'tsconfig.build.json'))
-    copyFileSync(TEMPLATES.VITE_CONFIG, join(fullPath, 'vite.config.ts'))
   }
 
   if (runInstall) {

--- a/tools/generate-react-queries/src/discover.ts
+++ b/tools/generate-react-queries/src/discover.ts
@@ -47,22 +47,21 @@ function discoverFromDirectory(packagesPath: string): Map<string, string> {
 
   for (const dir of readdirSync(fullPath)) {
     const dirPath = join(fullPath, dir)
-    if (!statSync(dirPath).isDirectory()) continue
-
-    // Read the actual package name from its package.json
-    const pkgJsonPath = join(dirPath, 'package.json')
-    if (!existsSync(pkgJsonPath)) {
-      console.warn(`  ⚠️  No package.json in ${dirPath}, skipping`)
-      continue
-    }
-
-    try {
-      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as { name?: string }
-      if (pkgJson.name) {
-        packages.set(pkgJson.name, dirPath)
+    if (statSync(dirPath).isDirectory()) {
+      // Read the actual package name from its package.json
+      const pkgJsonPath = join(dirPath, 'package.json')
+      if (existsSync(pkgJsonPath)) {
+        try {
+          const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as { name?: string }
+          if (pkgJson.name) {
+            packages.set(pkgJson.name, dirPath)
+          }
+        } catch {
+          console.warn(`  ⚠️  Could not read ${pkgJsonPath}, skipping`)
+        }
+      } else {
+        console.warn(`  ⚠️  No package.json in ${dirPath}, skipping`)
       }
-    } catch {
-      console.warn(`  ⚠️  Could not read ${pkgJsonPath}, skipping`)
     }
   }
 

--- a/tools/generate-react-queries/src/generate.ts
+++ b/tools/generate-react-queries/src/generate.ts
@@ -32,57 +32,40 @@ export async function generateFromMetadata(config: ReactQueriesConfig): Promise<
   // Preload namespace resolver for cross-package type references
   const namespaceResolver = await buildNamespaceResolver(config)
 
-  for (const [packageName, pkgDir] of sdkPackages) {
-    if (skipPackages.has(packageName)) {
-      console.log(`⏭️ Skipping ${packageName} (excluded by skipPackages)`)
-      continue
+  const processVersion = async (packageName: string, pkgDir: string, version: string): Promise<void> => {
+    if (isVersionSkipped(packageName, version)) {
+      console.log(`  ⏭️  Skipping ${packageName}/${version} (excluded by skipVersions)`)
+      return
     }
 
-    const versions = discoverVersions(pkgDir, metadataFileName)
+    try {
+      const metadata = await loadMetadata(pkgDir, version, metadataFileName)
 
-    if (versions.length === 0) {
-      console.log(` ⏭️ Skipping ${packageName} (no metadata found)`)
-      continue
-    }
-
-    console.log(`  📦 ${packageName}: ${versions.length} version(s): ${versions.join(', ')}`)
-
-    for (const version of versions) {
-      if (isVersionSkipped(packageName, version)) {
-        console.log(`  ⏭️  Skipping ${packageName}/${version} (excluded by skipVersions)`)
-        continue
+      if (!metadata?.services) {
+        console.warn(`    ⚠️  Invalid metadata for ${packageName}/${version}, skipping`)
+        return
       }
 
-      try {
-        const metadata = await loadMetadata(pkgDir, version, metadataFileName)
+      const { folderName, services } = metadata
+      const generatedDir = join(config.outputDir, folderName.toLowerCase(), config.generatedPath)
 
-        if (!metadata?.services) {
-          console.warn(`    ⚠️  Invalid metadata for ${packageName}/${version}, skipping`)
-          continue
-        }
+      if (existsSync(generatedDir)) {
+        rmSync(generatedDir, { recursive: true, force: true })
+      }
+      mkdirSync(generatedDir, { recursive: true })
 
-        const { folderName, services } = metadata
-        const generatedDir = join(config.outputDir, folderName.toLowerCase(), config.generatedPath)
+      const servicesToGenerate = services.filter(service => !skipServices.has(service.apiClass))
 
-        if (existsSync(generatedDir)) {
-          rmSync(generatedDir, { recursive: true, force: true })
-        }
-        mkdirSync(generatedDir, { recursive: true })
+      if (servicesToGenerate.length === 0) {
+        console.log(` ⏭️  Skipping ${packageName}/${version}: all services excluded by skipServices`)
+        return
+      }
 
-        const servicesToGenerate = services.filter(service => !skipServices.has(service.apiClass))
+      for (const service of servicesToGenerate) {
+        console.log(`📝 Generating hooks for ${service.apiClass}`)
 
-        if (servicesToGenerate.length === 0) {
-          console.log(` ⏭️  Skipping ${packageName}/${version}: all services excluded by skipServices`)
-          continue
-        }
-
-        for (const service of servicesToGenerate) {
-          console.log(`📝 Generating hooks for ${service.apiClass}`)
-
-          for (const method of service.methods) {
-            if (skipMethods.has(method.methodName)) continue
-            if (config.filters.skipPrivateMethods && method.isPrivate) continue
-
+        for (const method of service.methods) {
+          if (!skipMethods.has(method.methodName) && !(config.filters.skipPrivateMethods && method.isPrivate)) {
             // Standard query hook (e.g. useInstancev1APIGetServerQuery)
             const hookContent = generateQueryHook(method, service, metadata, config, packageName, namespaceResolver)
             const hookFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}Query.ts`
@@ -133,21 +116,39 @@ export async function generateFromMetadata(config: ReactQueriesConfig): Promise<
               writeFileSync(join(generatedDir, waiterFileName), waiterContent)
             }
           }
-
-          // One reload hook per service to invalidate all its queries
-          const reloadContent = generateReloadHook(service, metadata, config)
-          const reloadFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}Reload.ts`
-          writeFileSync(join(generatedDir, reloadFileName), reloadContent)
         }
 
-        // Barrel file re-exporting all generated hooks for this namespace
-        const indexContent = generateIndexFile(servicesToGenerate, metadata, config)
-        writeFileSync(join(generatedDir, config.naming.indexFile), indexContent)
+        // One reload hook per service to invalidate all its queries
+        const reloadContent = generateReloadHook(service, metadata, config)
+        const reloadFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}Reload.ts`
+        writeFileSync(join(generatedDir, reloadFileName), reloadContent)
+      }
 
-        console.log(`✅ Generated hooks for ${folderName}`)
-      } catch (error) {
-        console.error(`    ❌ Error loading ${packageName}/${version}/metadata:`, error)
-        throw error
+      // Barrel file re-exporting all generated hooks for this namespace
+      const indexContent = generateIndexFile(servicesToGenerate, metadata, config)
+      writeFileSync(join(generatedDir, config.naming.indexFile), indexContent)
+
+      console.log(`✅ Generated hooks for ${folderName}`)
+    } catch (error) {
+      console.error(`    ❌ Error loading ${packageName}/${version}/metadata:`, error)
+      throw error
+    }
+  }
+
+  for (const [packageName, pkgDir] of sdkPackages) {
+    if (skipPackages.has(packageName)) {
+      console.log(`⏭️ Skipping ${packageName} (excluded by skipPackages)`)
+    } else {
+      const versions = discoverVersions(pkgDir, metadataFileName)
+
+      if (versions.length === 0) {
+        console.log(` ⏭️ Skipping ${packageName} (no metadata found)`)
+      } else {
+        console.log(`  📦 ${packageName}: ${versions.length} version(s): ${versions.join(', ')}`)
+
+        for (const version of versions) {
+          await processVersion(packageName, pkgDir, version)
+        }
       }
     }
   }

--- a/tools/generate-react-queries/src/hook-generators.ts
+++ b/tools/generate-react-queries/src/hook-generators.ts
@@ -232,30 +232,29 @@ export function generateIndexFile(
     const serviceName = `${capitalize(folderName)}${service.apiClass}`
 
     for (const method of service.methods) {
-      if (skipMethods.has(method.methodName)) continue
-      if (config.filters.skipPrivateMethods && method.isPrivate) continue
-
-      const baseName = capitalize(method.methodName)
-      exports.push(
-        `export { ${config.naming.hookPrefix}${serviceName}${baseName}Query } from "./${config.naming.hookPrefix}${serviceName}${baseName}Query"`,
-      )
-
-      if (method.isList) {
+      if (!skipMethods.has(method.methodName) && !(config.filters.skipPrivateMethods && method.isPrivate)) {
+        const baseName = capitalize(method.methodName)
         exports.push(
-          `export { ${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery"`,
+          `export { ${config.naming.hookPrefix}${serviceName}${baseName}Query } from "./${config.naming.hookPrefix}${serviceName}${baseName}Query"`,
         )
-        if (!(config.filters.skipCursorAllHooks && method.paginationType === 'cursor')) {
+
+        if (method.isList) {
           exports.push(
-            `export { ${config.naming.hookPrefix}${serviceName}${baseName}AllQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}AllQuery"`,
+            `export { ${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery"`,
+          )
+          if (!(config.filters.skipCursorAllHooks && method.paginationType === 'cursor')) {
+            exports.push(
+              `export { ${config.naming.hookPrefix}${serviceName}${baseName}AllQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}AllQuery"`,
+            )
+          }
+        }
+
+        if (method.hasWaiter && !config.filters.skipWaiters) {
+          const waiterName = `${config.naming.waiterPrefix}${capitalize(method.methodName.replace(/^get/, ''))}`
+          exports.push(
+            `export { ${config.naming.hookPrefix}${serviceName}${waiterName}Query } from "./${config.naming.hookPrefix}${serviceName}${waiterName}Query"`,
           )
         }
-      }
-
-      if (method.hasWaiter && !config.filters.skipWaiters) {
-        const waiterName = `${config.naming.waiterPrefix}${capitalize(method.methodName.replace(/^get/, ''))}`
-        exports.push(
-          `export { ${config.naming.hookPrefix}${serviceName}${waiterName}Query } from "./${config.naming.hookPrefix}${serviceName}${waiterName}Query"`,
-        )
       }
     }
 

--- a/tools/generate-react-queries/src/namespace-resolver.ts
+++ b/tools/generate-react-queries/src/namespace-resolver.ts
@@ -72,17 +72,17 @@ export async function buildNamespaceResolver(config: ReactQueriesConfig): Promis
         for (const service of metadata.services) {
           for (const method of service.methods) {
             for (const nsPath of [method.returnTypeNamespace, method.listItemTypeNamespace]) {
-              if (!nsPath) continue
-              const normalized = normalizeNsPath(nsPath)
-              if (resolver.has(normalized)) continue
-              // Only register the path as owned by this package when it
-              // actually matches this package's own namespace prefix.
-              // Cross-package references (nsPath belongs to a different
-              // package) are left for that package to claim when it is
-              // iterated; if no package claims them, resolveTypeNamespace
-              // falls back to the current package's namespace.
-              if (normalized.startsWith(`${ownPathPrefix}/`)) {
-                resolver.set(normalized, { packageName, ns })
+              if (nsPath) {
+                const normalized = normalizeNsPath(nsPath)
+                // Only register the path as owned by this package when it
+                // actually matches this package's own namespace prefix.
+                // Cross-package references (nsPath belongs to a different
+                // package) are left for that package to claim when it is
+                // iterated; if no package claims them, resolveTypeNamespace
+                // falls back to the current package's namespace.
+                if (!resolver.has(normalized) && normalized.startsWith(`${ownPathPrefix}/`)) {
+                  resolver.set(normalized, { packageName, ns })
+                }
               }
             }
           }

--- a/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
@@ -103,42 +103,38 @@ export const generateAPI = async ({
   for (const [packageName] of sdkPackages) {
     if (skipPackages.has(packageName)) {
       stdout.write(`⚠️  Skipping ${packageName}: excluded package\n`)
-      continue
-    }
+    } else {
+      const versions = await loadVersions(packageName)
 
-    const versions = await loadVersions(packageName)
+      if (versions.length === 0) {
+        stdout.write(`⚠️  Skipping ${packageName}: no versions with metadata found\n`)
+      } else {
+        for (const version of versions) {
+          if (isVersionSkipped(packageName, version)) {
+            stdout.write(`⚠️  Skipping ${packageName}/${version}: excluded by skipVersions\n`)
+          } else {
+            const metadata = await loadMetadata(packageName, version)
 
-    if (versions.length === 0) {
-      stdout.write(`⚠️  Skipping ${packageName}: no versions with metadata found\n`)
-      continue
-    }
+            if (!metadata) {
+              stdout.write(`⚠️  Skipping ${packageName}/${version}: no queriesMetadata found\n`)
+            } else {
+              const namespace = metadata.folderName || metadata.namespace
+              const apis = metadata.services
+                .filter((service: { apiClass: string }) => !servicesToSkip.has(service.apiClass))
+                .map((service: { apiClass: string }) => service.apiClass)
+                .filter((apiClass: string) => apiClass && apiClass.length > 0)
 
-    for (const version of versions) {
-      if (isVersionSkipped(packageName, version)) {
-        stdout.write(`⚠️  Skipping ${packageName}/${version}: excluded by skipVersions\n`)
-        continue
-      }
-
-      const metadata = await loadMetadata(packageName, version)
-
-      if (!metadata) {
-        stdout.write(`⚠️  Skipping ${packageName}/${version}: no queriesMetadata found\n`)
-        continue
-      }
-
-      const namespace = metadata.folderName || metadata.namespace
-      const apis = metadata.services
-        .filter((service: { apiClass: string }) => !servicesToSkip.has(service.apiClass))
-        .map((service: { apiClass: string }) => service.apiClass)
-        .filter((apiClass: string) => apiClass && apiClass.length > 0)
-
-      if (apis.length > 0) {
-        result = {
-          ...result,
-          [namespace]: {
-            packageName,
-            apis,
-          },
+              if (apis.length > 0) {
+                result = {
+                  ...result,
+                  [namespace]: {
+                    packageName,
+                    apis,
+                  },
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/tools/generate-react-sdk/src/parseArgsCLI.ts
+++ b/tools/generate-react-sdk/src/parseArgsCLI.ts
@@ -22,9 +22,9 @@ export const parseArgsCLI = <T extends string[]>({ requiresValueArgs }: { requir
         // For arguments that require values, if no value is provided, skip them or use default
         if (requiresValueArgs?.includes(key) && (value === true || value === undefined)) {
           console.log(`⚠️  Warning: --${key} requires a value, using default`)
-          continue
+        } else {
+          cliArgs[key] = value as string | boolean
         }
-        cliArgs[key] = value as string | boolean
       }
     }
   }

--- a/tools/pnpm-auto-release/src/utils.ts
+++ b/tools/pnpm-auto-release/src/utils.ts
@@ -75,11 +75,11 @@ export const createTags = ({
       const remoteExists = exec(`git ls-remote --tags origin "refs/tags/${tag}"`, { cwd: root }).length > 0
       if (localExists || remoteExists) {
         logger(`[release] tag already exists, skipping: ${tag}`)
-        continue
+      } else {
+        exec(`git tag "${tag}" -m "${tag}"`, { cwd: root })
+        newTags.push(tag)
+        logger(`[release] tag: ${tag}`)
       }
-      exec(`git tag "${tag}" -m "${tag}"`, { cwd: root })
-      newTags.push(tag)
-      logger(`[release] tag: ${tag}`)
     }
   }
   return newTags
@@ -161,18 +161,19 @@ export const createChangesets = ({
 
   for (const line of commits.split('\n').filter(Boolean)) {
     const [sha, subject] = line.split('\u001F')
-    if (!sha) continue
-    const changedFiles = exec(`git diff-tree --no-commit-id --name-only -r ${sha}`, { cwd: root })
-      .split('\n')
-      .filter(Boolean)
+    if (sha) {
+      const changedFiles = exec(`git diff-tree --no-commit-id --name-only -r ${sha}`, { cwd: root })
+        .split('\n')
+        .filter(Boolean)
 
-    const affected = packages.filter(
-      pkg => pkg.relativePath && changedFiles.some(f => f.startsWith(`${pkg.relativePath}/`)),
-    )
+      const affected = packages.filter(
+        pkg => pkg.relativePath && changedFiles.some(f => f.startsWith(`${pkg.relativePath}/`)),
+      )
 
-    if (affected.length === 0) continue
-
-    createChangesetForPackages(root, affected, subject || defaultSummary)
-    logger(`[release] changeset (${sha.slice(0, 7)} -> ${affected.length} pkg)`)
+      if (affected.length > 0) {
+        createChangesetForPackages(root, affected, subject || defaultSummary)
+        logger(`[release] changeset (${sha.slice(0, 7)} -> ${affected.length} pkg)`)
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #3349

Removes all `eslint/no-continue` violations by replacing `continue` statements with `if`/`else` blocks or early `return`s, then removes the rule from `oxlint.config.ts`.

Changes:
- `tools/generate-packages/src/commands/deps.ts`: replaced 2 `continue` with nested `if` blocks
- `tools/generate-packages/src/commands/packages.ts`: replaced 1 `continue` with nested `if` block
- `tools/generate-react-queries/src/discover.ts`: replaced 2 `continue` with nested `if` blocks
- `tools/generate-react-queries/src/generate.ts`: extracted inner loop body into `processVersion` function, replaced 5 `continue` with early `return` / `if`/`else`
- `tools/generate-react-queries/src/hook-generators.ts`: combined 2 `continue` guards into single negated `if`
- `tools/generate-react-queries/src/namespace-resolver.ts`: replaced 2 `continue` with nested `if` block
- `tools/generate-react-sdk/src/generateAPI/generate-metadata.ts`: replaced 4 `continue` with nested `if`/`else` chains
- `tools/generate-react-sdk/src/parseArgsCLI.ts`: replaced 1 `continue` with `if`/`else`
- `tools/pnpm-auto-release/src/utils.ts`: replaced 3 `continue` with `if`/`else` blocks
- `oxlint.config.ts`: removed `eslint/no-continue` rule