### PR TITLE
fix(oxlint): remove eslint/no-unused-vars rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
     'typescript/consistent-type-definitions': 'warn',
     'eslint/no-console': 'warn',
     'eslint/no-continue': 'warn',
-    'eslint/no-unused-vars': 'warn',
     'eslint/max-statements': 'warn',
     'unicorn/catch-error-name': 'warn',
     'unicorn/explicit-length-check': 'warn',


### PR DESCRIPTION
## Context

This PR is part of the [Oxlint v1](https://github.com/scaleway/scaleway-sdk-js/milestone/1) effort to clean up the warning rules in `oxlint.config.ts`.

## Changes

- Removed the `eslint/no-unused-vars` rule from `oxlint.config.ts`.

There were no violations of this rule remaining in the codebase, so the rule line can be safely removed.

Closes #3350