### PR TITLE
fix(oxlint): fix eslint/max-statements violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   rules: {
     'typescript/no-unsafe-assignment': 'warn',
     'eslint/no-console': 'warn',
-    'eslint/max-statements': 'warn',
+
     // TODO: new errors from @scaleway/oxlint-config 1.x upgrade — fix later
     'eslint/curly': 'warn',
     'eslint/default-case': 'warn',

--- a/tools/generate-packages/src/commands/deps.ts
+++ b/tools/generate-packages/src/commands/deps.ts
@@ -28,6 +28,67 @@ function getAllGenTsFiles(dir: string, files: string[] = []): string[] {
   return files
 }
 
+function discoverPackages(src: string): PkgInfo[] {
+  return readdirSync(src, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .flatMap(e => {
+      const packageJsonPath = join(src, e.name, 'package.json')
+      if (!existsSync(packageJsonPath)) return []
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PkgInfo['packageJson']
+      return [{ name: e.name, path: join(src, e.name), packageJsonPath, packageJson }]
+    })
+}
+
+function collectImports(
+  srcDir: string,
+  importRegex: RegExp,
+  pkgMap: Map<string, PkgInfo>,
+  currentPkgName: string,
+): Set<string> {
+  const imports = new Set<string>()
+  for (const file of getAllGenTsFiles(srcDir)) {
+    const content = readFileSync(file, 'utf8')
+    importRegex.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = importRegex.exec(content)) !== null) {
+      const pkgName = match[1]?.split('/').slice(0, 2).join('/')
+      if (pkgName && pkgMap.has(pkgName) && pkgName !== currentPkgName) imports.add(pkgName)
+    }
+  }
+  return imports
+}
+
+function syncMissingDeps(pkg: PkgInfo, missing: string[], dryRun: boolean): void {
+  const allDeps = [
+    ...Object.entries(pkg.packageJson.dependencies ?? {}),
+    ...missing.map(d => [d, 'workspace:*'] as const),
+  ]
+  allDeps.sort(([a], [b]) => a.localeCompare(b))
+  pkg.packageJson.dependencies = Object.fromEntries(allDeps)
+  if (dryRun) {
+    console.log(`  🔍 DRY RUN: Would add to ${pkg.name}: ${missing.join(', ')}`)
+  } else {
+    writeFileSync(pkg.packageJsonPath, `${JSON.stringify(pkg.packageJson, null, 2)}\n`, 'utf8')
+    console.log(`  ✅ Updated ${pkg.name}: +${missing.length} deps`)
+  }
+}
+
+function syncPackage(pkg: PkgInfo, importRegex: RegExp, pkgMap: Map<string, PkgInfo>, dryRun: boolean): boolean {
+  const srcDir = join(pkg.path, 'src')
+  if (!existsSync(srcDir)) return false
+  const imports = collectImports(srcDir, importRegex, pkgMap, pkg.packageJson.name)
+  const missing = [...imports].filter(imp => !pkg.packageJson.dependencies?.[imp])
+  if (missing.length === 0) return false
+  syncMissingDeps(pkg, missing, dryRun)
+  return true
+}
+
+function runInstallIfNeeded(updated: number): void {
+  if (updated > 0) {
+    execSync('pnpm install --no-frozen-lockfile', { stdio: 'inherit', cwd: cwd() })
+  }
+}
+
 /**
  * Sync `workspace:*` dependencies in each generated package's `package.json`.
  *
@@ -44,58 +105,16 @@ function getAllGenTsFiles(dir: string, files: string[] = []): string[] {
 export const deps = async ({ src, config, dryRun = false }: DepsOptions): Promise<void> => {
   if (!existsSync(src)) throw new Error(`Directory not found: ${src}`)
 
-  const prefix = escapeRegExp(config.sdkPackagePrefix)
-  const importRegex = new RegExp(`from\\s+['"]((${prefix})[^'"]+)['"]`, 'g')
-
-  const packages: PkgInfo[] = readdirSync(src, { withFileTypes: true })
-    .filter(e => e.isDirectory())
-    .flatMap(e => {
-      const packageJsonPath = join(src, e.name, 'package.json')
-      if (!existsSync(packageJsonPath)) return []
-      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PkgInfo['packageJson']
-      return [{ name: e.name, path: join(src, e.name), packageJsonPath, packageJson }]
-    })
-
+  const importRegex = new RegExp(`from\\s+['"]((${escapeRegExp(config.sdkPackagePrefix)})[^'"]+)['"]`, 'g')
+  const packages = discoverPackages(src)
   const pkgMap = new Map(packages.map(p => [p.packageJson.name, p]))
   let updated = 0
 
   for (const pkg of packages) {
-    const srcDir = join(pkg.path, 'src')
-    if (existsSync(srcDir)) {
-      const imports = new Set<string>()
-      for (const file of getAllGenTsFiles(srcDir)) {
-        const content = readFileSync(file, 'utf8')
-        importRegex.lastIndex = 0
-        let match: RegExpExecArray | null
-        while ((match = importRegex.exec(content)) !== null) {
-          const pkgName = match[1]?.split('/').slice(0, 2).join('/')
-          if (pkgName && pkgMap.has(pkgName) && pkgName !== pkg.packageJson.name) imports.add(pkgName)
-        }
-      }
-
-      const missing = [...imports].filter(imp => !pkg.packageJson.dependencies?.[imp])
-      if (missing.length > 0) {
-        const allDeps = [
-          ...Object.entries(pkg.packageJson.dependencies ?? {}),
-          ...missing.map(d => [d, 'workspace:*'] as const),
-        ]
-        allDeps.sort(([a], [b]) => a.localeCompare(b))
-        pkg.packageJson.dependencies = Object.fromEntries(allDeps)
-
-        if (dryRun) {
-          console.log(`  🔍 DRY RUN: Would add to ${pkg.name}: ${missing.join(', ')}`)
-        } else {
-          writeFileSync(pkg.packageJsonPath, `${JSON.stringify(pkg.packageJson, null, 2)}\n`, 'utf8')
-          console.log(`  ✅ Updated ${pkg.name}: +${missing.length} deps`)
-        }
-        updated++
-      }
-    }
+    if (syncPackage(pkg, importRegex, pkgMap, dryRun)) updated++
   }
 
   console.log(`\n📊 Packages updated: ${updated}`)
-  if (updated > 0) {
-    execSync('pnpm install --no-frozen-lockfile', { stdio: 'inherit', cwd: cwd() })
-  }
+  runInstallIfNeeded(updated)
   if (dryRun) console.log('🔍 DRY RUN - no changes made')
 }

--- a/tools/generate-packages/src/commands/packages.ts
+++ b/tools/generate-packages/src/commands/packages.ts
@@ -34,6 +34,65 @@ const CUSTOM = {
 
 export type PackagesOptions = { src: string; runInstall?: boolean }
 
+function ensurePackageJson(fullPath: string, productDir: string, templateString: string): void {
+  const packageJsonPath = join(fullPath, 'package.json')
+  if (!existsSync(packageJsonPath)) {
+    const pkg = renderTemplatePackageJson(templateString, { name: snakeToSlug(productDir) })
+    writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2))
+  }
+}
+
+function writeVersionExports(srcPath: string, indexGenPath: string, productDir: string): void {
+  for (const versionDir of readdirSync(srcPath)) {
+    if (statSync(join(srcPath, versionDir)).isDirectory()) {
+      const exportPath = CUSTOM.PRODUCT_VERSION_EXPORT.has(`${productDir}/${versionDir}`)
+        ? `./${versionDir}/index.js`
+        : `./${versionDir}/index.gen.js`
+      appendFileSync(indexGenPath, `\nexport * as ${snakeToPascal(productDir)}${versionDir} from '${exportPath}'`)
+    }
+  }
+}
+
+function writeMetadataGen(srcPath: string, productDir: string, templateString: string): void {
+  const versionsList = readdirSync(srcPath)
+    .filter(d => statSync(join(srcPath, d)).isDirectory())
+    .map(v => `"${v}"`)
+    .join(', ')
+  writeFileSync(
+    join(srcPath, 'metadata.gen.ts'),
+    renderTemplate(templateString, {
+      name: snakeToSlug(productDir),
+      displayName: snakeToDisplayName(productDir),
+      versions: versionsList,
+    }),
+  )
+}
+
+function copyConfigTemplates(fullPath: string): void {
+  copyFileSync(TEMPLATES.TS_CONFIG, join(fullPath, 'tsconfig.json'))
+  copyFileSync(TEMPLATES.TS_CONFIG_BUILD, join(fullPath, 'tsconfig.build.json'))
+  copyFileSync(TEMPLATES.VITE_CONFIG, join(fullPath, 'vite.config.ts'))
+}
+
+function processProductDir(
+  productDir: string,
+  inputPathDir: string,
+  templateString: string,
+  metadataTsTemplateString: string,
+): void {
+  const fullPath = join(inputPathDir, productDir)
+  if (!statSync(fullPath).isDirectory() || CUSTOM.PRODUCT_EXPORT.has(productDir)) return
+
+  ensurePackageJson(fullPath, productDir, templateString)
+
+  const srcPath = join(fullPath, 'src')
+  const indexGenPath = join(srcPath, 'index.gen.ts')
+  writeFileSync(indexGenPath, AUTO_GENERATE_MESSAGE)
+  writeVersionExports(srcPath, indexGenPath, productDir)
+  writeMetadataGen(srcPath, productDir, metadataTsTemplateString)
+  copyConfigTemplates(fullPath)
+}
+
 /**
  * Generate per-product configuration files from templates.
  *
@@ -51,43 +110,7 @@ export const packages = async ({ src: inputPathDir, runInstall = true }: Package
   const metadataTsTemplateString = readFileSync(TEMPLATES.METADATA_TS, 'utf8')
 
   for (const productDir of readdirSync(inputPathDir)) {
-    const fullPath = join(inputPathDir, productDir)
-    if (statSync(fullPath).isDirectory() && !CUSTOM.PRODUCT_EXPORT.has(productDir)) {
-      const packageJsonPath = join(fullPath, 'package.json')
-      if (!existsSync(packageJsonPath)) {
-        const pkg = renderTemplatePackageJson(templateString, { name: snakeToSlug(productDir) })
-        writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2))
-      }
-
-      const srcPath = join(fullPath, 'src')
-      const indexGenPath = join(srcPath, 'index.gen.ts')
-      writeFileSync(indexGenPath, AUTO_GENERATE_MESSAGE)
-      for (const versionDir of readdirSync(srcPath)) {
-        if (statSync(join(srcPath, versionDir)).isDirectory()) {
-          const exportPath = CUSTOM.PRODUCT_VERSION_EXPORT.has(`${productDir}/${versionDir}`)
-            ? `./${versionDir}/index.js`
-            : `./${versionDir}/index.gen.js`
-          appendFileSync(indexGenPath, `\nexport * as ${snakeToPascal(productDir)}${versionDir} from '${exportPath}'`)
-        }
-      }
-
-      const versionsList = readdirSync(srcPath)
-        .filter(d => statSync(join(srcPath, d)).isDirectory())
-        .map(v => `"${v}"`)
-        .join(', ')
-      writeFileSync(
-        join(srcPath, 'metadata.gen.ts'),
-        renderTemplate(metadataTsTemplateString, {
-          name: snakeToSlug(productDir),
-          displayName: snakeToDisplayName(productDir),
-          versions: versionsList,
-        }),
-      )
-
-      copyFileSync(TEMPLATES.TS_CONFIG, join(fullPath, 'tsconfig.json'))
-      copyFileSync(TEMPLATES.TS_CONFIG_BUILD, join(fullPath, 'tsconfig.build.json'))
-      copyFileSync(TEMPLATES.VITE_CONFIG, join(fullPath, 'vite.config.ts'))
-    }
+    processProductDir(productDir, inputPathDir, templateString, metadataTsTemplateString)
   }
 
   if (runInstall) {

--- a/tools/generate-packages/src/commands/sdk.ts
+++ b/tools/generate-packages/src/commands/sdk.ts
@@ -43,49 +43,62 @@ const getGeneratedPackages = (dir: string, excludeSuffix?: string): PackageJSON[
  * @param options.config - Loaded configuration defining SDK targets and filters
  * @param options.runInstall - Run `pnpm install` after updating (default: true)
  */
+function rebuildDeps(sdkPkg: PackageJSON, depType: string, config: Config, validPackages: PackageJSON[]): void {
+  const field =
+    depType === 'dependencies'
+      ? 'dependencies'
+      : depType === 'peerDependencies'
+        ? 'peerDependencies'
+        : 'devDependencies'
+  const existing = sdkPkg[field] ?? {}
+  const kept = Object.fromEntries(
+    Object.entries(existing).filter(([name]) => !name.startsWith(config.sdkPackagePrefix)),
+  )
+  const added = Object.fromEntries(
+    validPackages.length > 0 ? validPackages.map(p => [p.name, 'workspace:*' as const]) : [],
+  )
+  sdkPkg[field] = { ...kept, ...added }
+}
+
+function rebuildAllDeps(
+  sdkPkg: PackageJSON,
+  s: Config['sdks'][number],
+  config: Config,
+  validPackages: PackageJSON[],
+): void {
+  for (const depType of s.depsTypes) {
+    rebuildDeps(sdkPkg, depType, config, validPackages)
+  }
+}
+
+function writeSdkIndex(s: Config['sdks'][number], validPackages: PackageJSON[]): void {
+  if (!s.shouldUpdateIndex) return
+  const indexContent =
+    '// Auto-generated exports from all SDK packages\n\n' +
+    validPackages.map(p => `export * from '${p.name}'\n`).join('')
+  writeFileSync(s.index, indexContent, 'utf8')
+  console.log(`Updated ${s.index} with exports for ${validPackages.length} packages`)
+}
+
+function updateSdk(s: Config['sdks'][number], src: string, config: Config): void {
+  const generatedPackages = getGeneratedPackages(src, s.excludeSuffix)
+  if (!generatedPackages || generatedPackages.length === 0) {
+    console.warn('No generated packages found. Nothing to update.')
+    exit(1)
+  }
+  const validPackages = generatedPackages.filter(p => !s.ignoredPackages.includes(p.name))
+  const sdkPkg = JSON.parse(readFileSync(s.path, 'utf8')) as PackageJSON
+  rebuildAllDeps(sdkPkg, s, config, validPackages)
+  writeFileSync(s.path, `${JSON.stringify(sdkPkg, null, 2)}\n`, 'utf8')
+  console.log(`Updated ${s.path} with ${validPackages.length} packages`)
+  writeSdkIndex(s, validPackages)
+}
+
 export const sdk = async ({ src, config, runInstall = true }: SdkOptions): Promise<void> => {
   console.log('Starting SDK package update process...')
 
   for (const s of config.sdks) {
-    const generatedPackages = getGeneratedPackages(src, s.excludeSuffix)
-    if (!generatedPackages || generatedPackages.length === 0) {
-      console.warn('No generated packages found. Nothing to update.')
-      exit(1)
-    }
-
-    const validPackages = generatedPackages.filter(p => !s.ignoredPackages.includes(p.name))
-    const validNames = new Set(validPackages.map(p => p.name))
-
-    const sdkPkg = JSON.parse(readFileSync(s.path, 'utf8')) as PackageJSON
-
-    // Rebuild each dependency section: keep non-SDK deps, replace SDK deps with current set
-    for (const depType of s.depsTypes) {
-      const field =
-        depType === 'dependencies'
-          ? 'dependencies'
-          : depType === 'peerDependencies'
-            ? 'peerDependencies'
-            : 'devDependencies'
-      const existing = sdkPkg[field] ?? {}
-      const kept = Object.fromEntries(
-        Object.entries(existing).filter(([name]) => !name.startsWith(config.sdkPackagePrefix)),
-      )
-      const added = Object.fromEntries(
-        validNames.size > 0 ? validPackages.map(p => [p.name, 'workspace:*' as const]) : [],
-      )
-      sdkPkg[field] = { ...kept, ...added }
-    }
-
-    writeFileSync(s.path, `${JSON.stringify(sdkPkg, null, 2)}\n`, 'utf8')
-    console.log(`Updated ${s.path} with ${validPackages.length} packages`)
-
-    if (s.shouldUpdateIndex) {
-      const indexContent =
-        '// Auto-generated exports from all SDK packages\n\n' +
-        validPackages.map(p => `export * from '${p.name}'\n`).join('')
-      writeFileSync(s.index, indexContent, 'utf8')
-      console.log(`Updated ${s.index} with exports for ${validPackages.length} packages`)
-    }
+    updateSdk(s, src, config)
   }
 
   if (runInstall) {

--- a/tools/generate-packages/src/commands/setup.ts
+++ b/tools/generate-packages/src/commands/setup.ts
@@ -37,6 +37,71 @@ function walkHasGenFiles(root: string): boolean {
   return false
 }
 
+function discoverNewProducts(src: string): { name: string }[] {
+  return readdirSync(src)
+    .filter(name => statSync(join(src, name)).isDirectory())
+    .map(name => ({
+      name,
+      hasGenFiles: walkHasGenFiles(join(src, name, 'src')),
+      hasPackageJson: existsSync(join(src, name, 'package.json')),
+    }))
+    .filter(p => p.hasGenFiles && !p.hasPackageJson)
+}
+
+function logNewProducts(newProducts: { name: string }[]): void {
+  console.log(`📦 New products: ${newProducts.length}`)
+  if (newProducts.length > 0) newProducts.forEach(p => console.log(`  - ${p.name}`))
+}
+
+function checkEarlyExit(newProducts: { name: string }[], dryRun: boolean): number | null {
+  if (newProducts.length === 0) {
+    console.log('✅ No new products to configure')
+    return 0
+  }
+  if (dryRun) {
+    console.log('🔍 DRY RUN: Would run packages + sdk + deps + install')
+    return 0
+  }
+  return null
+}
+
+function addProductsToSdk(sdkPkgPath: string, newProducts: { name: string }[], scope: string): void {
+  const sdkPkg = JSON.parse(readFileSync(sdkPkgPath, 'utf8')) as PackageJSON
+  sdkPkg.dependencies = sdkPkg.dependencies ?? {}
+  for (const p of newProducts) {
+    const pkgName = `${scope}/sdk-${snakeToSlug(p.name)}`
+    if (!sdkPkg.dependencies[pkgName]) {
+      sdkPkg.dependencies[pkgName] = 'workspace:*'
+      console.log(`  ✅ ${pkgName}`)
+    }
+  }
+  sdkPkg.dependencies = Object.fromEntries(Object.entries(sdkPkg.dependencies).sort(([a], [b]) => a.localeCompare(b)))
+  writeFileSync(sdkPkgPath, `${JSON.stringify(sdkPkg, null, 2)}\n`, 'utf8')
+}
+
+async function generateAndUpdateProducts(
+  src: string,
+  config: Config,
+  sdkPkgPath: string,
+  newProducts: { name: string }[],
+  scope: string,
+): Promise<void> {
+  console.log('⚙️  Generating package configs...')
+  await runPackages({ src, runInstall: false })
+  console.log(`📝 Adding deps to ${sdkPkgPath} (scope: ${scope})...`)
+  addProductsToSdk(sdkPkgPath, newProducts, scope)
+  console.log('📝 Updating SDK exports...')
+  await runSdk({ src, config, runInstall: false })
+  await runDeps({ src, config })
+}
+
+function runInstallStep(install: boolean): void {
+  if (install) {
+    console.log('📦 Installing dependencies...')
+    execSync('pnpm install --no-frozen-lockfile', { stdio: 'inherit', cwd: cwd() })
+  }
+}
+
 /**
  * Detect and onboard new products that have generated code but no `package.json`.
  *
@@ -65,57 +130,14 @@ export const setup = async ({
 }: SetupOptions): Promise<number> => {
   if (!existsSync(src)) throw new Error(`Directory not found: ${src}`)
 
-  // 1) Find new products (has .gen.ts but no package.json)
-  const newProducts = readdirSync(src)
-    .filter(name => statSync(join(src, name)).isDirectory())
-    .map(name => ({
-      name,
-      hasGenFiles: walkHasGenFiles(join(src, name, 'src')),
-      hasPackageJson: existsSync(join(src, name, 'package.json')),
-    }))
-    .filter(p => p.hasGenFiles && !p.hasPackageJson)
+  const newProducts = discoverNewProducts(src)
+  logNewProducts(newProducts)
 
-  console.log(`📦 New products: ${newProducts.length}`)
-  if (newProducts.length > 0) newProducts.forEach(p => console.log(`  - ${p.name}`))
+  const earlyExit = checkEarlyExit(newProducts, dryRun)
+  if (earlyExit !== null) return earlyExit
 
-  if (newProducts.length === 0) {
-    console.log('✅ No new products to configure')
-    return 0
-  }
-
-  if (dryRun) {
-    console.log('🔍 DRY RUN: Would run packages + sdk + deps + install')
-    return 0
-  }
-
-  // 2) Generate package configs
-  console.log('⚙️  Generating package configs...')
-  await runPackages({ src, runInstall: false })
-
-  // 3) Add new products to SDK package.json
-  console.log(`📝 Adding deps to ${sdkPkgPath} (scope: ${scope})...`)
-  const sdkPkg = JSON.parse(readFileSync(sdkPkgPath, 'utf8')) as PackageJSON
-  sdkPkg.dependencies = sdkPkg.dependencies ?? {}
-  for (const p of newProducts) {
-    const pkgName = `${scope}/sdk-${snakeToSlug(p.name)}`
-    if (!sdkPkg.dependencies[pkgName]) {
-      sdkPkg.dependencies[pkgName] = 'workspace:*'
-      console.log(`  ✅ ${pkgName}`)
-    }
-  }
-  sdkPkg.dependencies = Object.fromEntries(Object.entries(sdkPkg.dependencies).sort(([a], [b]) => a.localeCompare(b)))
-  writeFileSync(sdkPkgPath, `${JSON.stringify(sdkPkg, null, 2)}\n`, 'utf8')
-
-  // 4) Update SDK exports + sync deps
-  console.log('📝 Updating SDK exports...')
-  await runSdk({ src, config, runInstall: false })
-  await runDeps({ src, config })
-
-  // 5) Install
-  if (install) {
-    console.log('📦 Installing dependencies...')
-    execSync('pnpm install --no-frozen-lockfile', { stdio: 'inherit', cwd: cwd() })
-  }
+  await generateAndUpdateProducts(src, config, sdkPkgPath, newProducts, scope)
+  runInstallStep(install)
 
   console.log(`✅ Setup complete: ${newProducts.length} product(s) configured`)
   return 0

--- a/tools/generate-react-queries/src/discover.ts
+++ b/tools/generate-react-queries/src/discover.ts
@@ -49,37 +49,40 @@ export function discoverSdkPackages(config: ReactQueriesConfig): Map<string, str
  * Scan a directory where each subdirectory is an SDK package.
  * e.g. packages_generated/instance/, packages_generated/k8s/, etc.
  */
-function discoverFromDirectory(packagesPath: string): Map<string, string> {
-  const fullPath = resolve(packagesPath)
+function tryReadPackageDir(dirPath: string, packages: Map<string, string>): void {
+  const pkgJsonPath = join(dirPath, 'package.json')
+  if (!existsSync(pkgJsonPath)) {
+    console.warn(`  ⚠️  No package.json in ${dirPath}, skipping`)
+    return
+  }
+  try {
+    const pkgJson: unknown = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+    if (isPackageJsonWithName(pkgJson) && pkgJson.name) {
+      packages.set(pkgJson.name, dirPath)
+    }
+  } catch {
+    console.warn(`  ⚠️  Could not read ${pkgJsonPath}, skipping`)
+  }
+}
 
+function scanPackageDirectory(fullPath: string): Map<string, string> {
   if (!existsSync(fullPath)) {
     console.warn(`⚠️  Packages directory not found: ${fullPath}`)
     return new Map()
   }
 
   const packages = new Map<string, string>()
-
   for (const dir of readdirSync(fullPath)) {
     const dirPath = join(fullPath, dir)
-    if (!statSync(dirPath).isDirectory()) continue
-
-    // Read the actual package name from its package.json
-    const pkgJsonPath = join(dirPath, 'package.json')
-    if (!existsSync(pkgJsonPath)) {
-      console.warn(`  ⚠️  No package.json in ${dirPath}, skipping`)
-      continue
-    }
-
-    try {
-      const pkgJson: unknown = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
-      if (isPackageJsonWithName(pkgJson) && pkgJson.name) {
-        packages.set(pkgJson.name, dirPath)
-      }
-    } catch {
-      console.warn(`  ⚠️  Could not read ${pkgJsonPath}, skipping`)
+    if (statSync(dirPath).isDirectory()) {
+      tryReadPackageDir(dirPath, packages)
     }
   }
+  return packages
+}
 
+function discoverFromDirectory(packagesPath: string): Map<string, string> {
+  const packages = scanPackageDirectory(resolve(packagesPath))
   console.log(`📦 Found ${packages.size} SDK packages in ${packagesPath}`)
   return packages
 }
@@ -159,6 +162,31 @@ export function discoverVersions(pkgDir: string, metadataFileName: string): stri
 }
 
 /**
+ * Merge utils-metadata services into the main metadata.
+ * Utils methods are merged into matching services by apiClass to avoid duplicate services.
+ */
+function mergeUtilsServices(metadata: QueriesMetadata, utilsMetadata: QueriesMetadata): void {
+  if (!utilsMetadata?.services) return
+  for (const utilsService of utilsMetadata.services) {
+    const existing = metadata.services.find(s => s.apiClass === utilsService.apiClass)
+    if (existing) {
+      existing.methods = [...existing.methods, ...utilsService.methods]
+    } else {
+      metadata.services = [...metadata.services, utilsService]
+    }
+  }
+}
+
+async function loadUtilsMetadata(pkgDir: string, version: string, metadata: QueriesMetadata): Promise<void> {
+  const utilsMetadataPath = join(pkgDir, 'dist', version, 'utils-metadata.js')
+  if (!existsSync(utilsMetadataPath)) return
+  const utilsModule: unknown = await import(utilsMetadataPath)
+  if (!isQueriesMetadataModule(utilsModule)) return
+  const utilsMetadata: QueriesMetadata = structuredClone(utilsModule.queriesMetadata)
+  mergeUtilsServices(metadata, utilsMetadata)
+}
+
+/**
  * Load metadata from a package's dist.
  * Also loads utils-metadata.js if it exists (for hand-written api.utils.ts methods)
  * and merges its services into the main metadata.
@@ -177,25 +205,7 @@ export async function loadMetadata(
   // Deep clone to avoid mutating the cached module singleton across multiple calls
   const metadata: QueriesMetadata = structuredClone(module.queriesMetadata)
 
-  // Load utils-metadata if it exists (hand-written, for api.utils.ts methods)
-  const utilsMetadataPath = join(pkgDir, 'dist', version, 'utils-metadata.js')
-  if (existsSync(utilsMetadataPath)) {
-    const utilsModule: unknown = await import(utilsMetadataPath)
-    if (isQueriesMetadataModule(utilsModule)) {
-      const utilsMetadata: QueriesMetadata = structuredClone(utilsModule.queriesMetadata)
-      if (utilsMetadata?.services) {
-        // Merge utils methods into matching services by apiClass to avoid duplicate services
-        for (const utilsService of utilsMetadata.services) {
-          const existing = metadata.services.find(s => s.apiClass === utilsService.apiClass)
-          if (existing) {
-            existing.methods = [...existing.methods, ...utilsService.methods]
-          } else {
-            metadata.services = [...metadata.services, utilsService]
-          }
-        }
-      }
-    }
-  }
+  await loadUtilsMetadata(pkgDir, version, metadata)
 
   return metadata
 }

--- a/tools/generate-react-queries/src/generate.ts
+++ b/tools/generate-react-queries/src/generate.ts
@@ -5,7 +5,7 @@
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import type { ReactQueriesConfig } from './config.ts'
+import type { QueriesMetadata, QueryMethod, ReactQueriesConfig, ServiceMetadata } from './config.ts'
 import { capitalize } from './config.ts'
 import { discoverSdkPackages, discoverVersions, loadMetadata } from './discover.ts'
 import {
@@ -16,141 +16,205 @@ import {
   generateReloadHook,
 } from './hook-generators.ts'
 import { buildNamespaceResolver } from './namespace-resolver.ts'
+import type { ResolvedNamespace } from './namespace-resolver.ts'
 
-export async function generateFromMetadata(config: ReactQueriesConfig): Promise<void> {
-  const sdkPackages = discoverSdkPackages(config)
-  const skipMethods = new Set(config.filters.skipMethods)
-  const skipServices = new Set(config.filters.skipServices)
-  const skipVersions = new Set(config.filters.skipVersions)
-  const { metadataFileName } = config.naming
+type GenerationContext = {
+  config: ReactQueriesConfig
+  metadataFileName: string
+  skipMethods: Set<string>
+  skipServices: Set<string>
+  skipVersions: Set<string>
+  skipPackages: Set<string>
+  namespaceResolver: Map<string, ResolvedNamespace>
+}
 
-  const skipPackages = new Set(config.filters.skipPackages)
+function prepareGeneratedDir(ctx: GenerationContext, folderName: string): string {
+  const generatedDir = join(ctx.config.outputDir, folderName.toLowerCase(), ctx.config.generatedPath)
+  if (existsSync(generatedDir)) {
+    rmSync(generatedDir, { recursive: true, force: true })
+  }
+  mkdirSync(generatedDir, { recursive: true })
+  return generatedDir
+}
 
-  const isVersionSkipped = (packageName: string, version: string): boolean =>
-    skipVersions.has(`${packageName}@${version}`) || skipVersions.has(version)
-
-  // Preload namespace resolver for cross-package type references
-  const namespaceResolver = await buildNamespaceResolver(config)
-
-  const processVersion = async (packageName: string, pkgDir: string, version: string): Promise<void> => {
-    if (isVersionSkipped(packageName, version)) {
-      console.log(`  ⏭️  Skipping ${packageName}/${version} (excluded by skipVersions)`)
-      return
-    }
-
-    try {
-      const metadata = await loadMetadata(pkgDir, version, metadataFileName)
-
-      if (!metadata?.services) {
-        console.warn(`    ⚠️  Invalid metadata for ${packageName}/${version}, skipping`)
-        return
-      }
-
-      const { folderName, services } = metadata
-      const generatedDir = join(config.outputDir, folderName.toLowerCase(), config.generatedPath)
-
-      if (existsSync(generatedDir)) {
-        rmSync(generatedDir, { recursive: true, force: true })
-      }
-      mkdirSync(generatedDir, { recursive: true })
-
-      const servicesToGenerate = services.filter(service => !skipServices.has(service.apiClass))
-
-      if (servicesToGenerate.length === 0) {
-        console.log(` ⏭️  Skipping ${packageName}/${version}: all services excluded by skipServices`)
-        return
-      }
-
-      for (const service of servicesToGenerate) {
-        console.log(`📝 Generating hooks for ${service.apiClass}`)
-
-        for (const method of service.methods) {
-          if (!skipMethods.has(method.methodName) && !(config.filters.skipPrivateMethods && method.isPrivate)) {
-            // Standard query hook (e.g. useInstancev1APIGetServerQuery)
-            const hookContent = generateQueryHook(method, service, metadata, config, packageName, namespaceResolver)
-            const hookFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}Query.ts`
-            writeFileSync(join(generatedDir, hookFileName), hookContent)
-
-            // List methods get additional "all" and "infinite" variants
-            if (method.isList) {
-              if (!(config.filters.skipCursorAllHooks && method.paginationType === 'cursor')) {
-                const allContent = generateAllQueryHook(
-                  method,
-                  service,
-                  metadata,
-                  config,
-                  packageName,
-                  namespaceResolver,
-                )
-                const allFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}AllQuery.ts`
-                writeFileSync(join(generatedDir, allFileName), allContent)
-              }
-
-              const infiniteContent = generateInfiniteQueryHook(
-                method,
-                service,
-                metadata,
-                config,
-                packageName,
-                namespaceResolver,
-              )
-              const infiniteFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}InfiniteQuery.ts`
-              writeFileSync(join(generatedDir, infiniteFileName), infiniteContent)
-            }
-
-            // Methods with hasWaiter get a polling hook (e.g. useWaitForServer)
-            if (method.hasWaiter && !config.filters.skipWaiters) {
-              const waiterMethod = {
-                ...method,
-                methodName: `waitFor${capitalize(method.methodName.replace('get', ''))}`,
-              }
-              const waiterContent = generateQueryHook(
-                waiterMethod,
-                service,
-                metadata,
-                config,
-                packageName,
-                namespaceResolver,
-              )
-              const waiterFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${config.naming.waiterPrefix}${capitalize(method.methodName.replace('get', ''))}Query.ts`
-              writeFileSync(join(generatedDir, waiterFileName), waiterContent)
-            }
-          }
-        }
-
-        // One reload hook per service to invalidate all its queries
-        const reloadContent = generateReloadHook(service, metadata, config)
-        const reloadFileName = `${config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}Reload.ts`
-        writeFileSync(join(generatedDir, reloadFileName), reloadContent)
-      }
-
-      // Barrel file re-exporting all generated hooks for this namespace
-      const indexContent = generateIndexFile(servicesToGenerate, metadata, config)
-      writeFileSync(join(generatedDir, config.naming.indexFile), indexContent)
-
-      console.log(`✅ Generated hooks for ${folderName}`)
-    } catch (error) {
-      console.error(`    ❌ Error loading ${packageName}/${version}/metadata:`, error)
-      throw error
-    }
+function writeListMethodHooks(
+  method: QueryMethod,
+  service: ServiceMetadata,
+  metadata: QueriesMetadata,
+  ctx: GenerationContext,
+  packageName: string,
+  generatedDir: string,
+  folderName: string,
+): void {
+  if (!(ctx.config.filters.skipCursorAllHooks && method.paginationType === 'cursor')) {
+    const allContent = generateAllQueryHook(method, service, metadata, ctx.config, packageName, ctx.namespaceResolver)
+    const allFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}AllQuery.ts`
+    writeFileSync(join(generatedDir, allFileName), allContent)
   }
 
-  for (const [packageName, pkgDir] of sdkPackages) {
-    if (skipPackages.has(packageName)) {
-      console.log(`⏭️ Skipping ${packageName} (excluded by skipPackages)`)
-    } else {
-      const versions = discoverVersions(pkgDir, metadataFileName)
+  const infiniteContent = generateInfiniteQueryHook(
+    method,
+    service,
+    metadata,
+    ctx.config,
+    packageName,
+    ctx.namespaceResolver,
+  )
+  const infiniteFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}InfiniteQuery.ts`
+  writeFileSync(join(generatedDir, infiniteFileName), infiniteContent)
+}
 
-      if (versions.length === 0) {
-        console.log(` ⏭️ Skipping ${packageName} (no metadata found)`)
-      } else {
-        console.log(`  📦 ${packageName}: ${versions.length} version(s): ${versions.join(', ')}`)
+function writeWaiterHook(
+  method: QueryMethod,
+  service: ServiceMetadata,
+  metadata: QueriesMetadata,
+  ctx: GenerationContext,
+  packageName: string,
+  generatedDir: string,
+  folderName: string,
+): void {
+  const waiterMethod = {
+    ...method,
+    methodName: `waitFor${capitalize(method.methodName.replace('get', ''))}`,
+  }
+  const waiterContent = generateQueryHook(
+    waiterMethod,
+    service,
+    metadata,
+    ctx.config,
+    packageName,
+    ctx.namespaceResolver,
+  )
+  const waiterFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${ctx.config.naming.waiterPrefix}${capitalize(method.methodName.replace('get', ''))}Query.ts`
+  writeFileSync(join(generatedDir, waiterFileName), waiterContent)
+}
 
-        for (const version of versions) {
-          await processVersion(packageName, pkgDir, version)
-        }
-      }
+function writeMethodHooks(
+  method: QueryMethod,
+  service: ServiceMetadata,
+  metadata: QueriesMetadata,
+  ctx: GenerationContext,
+  packageName: string,
+  generatedDir: string,
+  folderName: string,
+): void {
+  const hookContent = generateQueryHook(method, service, metadata, ctx.config, packageName, ctx.namespaceResolver)
+  const hookFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}Query.ts`
+  writeFileSync(join(generatedDir, hookFileName), hookContent)
+
+  if (method.isList) {
+    writeListMethodHooks(method, service, metadata, ctx, packageName, generatedDir, folderName)
+  }
+
+  if (method.hasWaiter && !ctx.config.filters.skipWaiters) {
+    writeWaiterHook(method, service, metadata, ctx, packageName, generatedDir, folderName)
+  }
+}
+
+function writeServiceHooks(
+  service: ServiceMetadata,
+  metadata: QueriesMetadata,
+  ctx: GenerationContext,
+  packageName: string,
+  generatedDir: string,
+  folderName: string,
+): void {
+  console.log(`📝 Generating hooks for ${service.apiClass}`)
+  for (const method of service.methods) {
+    if (!ctx.skipMethods.has(method.methodName) && !(ctx.config.filters.skipPrivateMethods && method.isPrivate)) {
+      writeMethodHooks(method, service, metadata, ctx, packageName, generatedDir, folderName)
     }
+  }
+  const reloadContent = generateReloadHook(service, metadata, ctx.config)
+  const reloadFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}Reload.ts`
+  writeFileSync(join(generatedDir, reloadFileName), reloadContent)
+}
+
+function generateServiceHooks(
+  services: ServiceMetadata[],
+  metadata: QueriesMetadata,
+  ctx: GenerationContext,
+  packageName: string,
+  generatedDir: string,
+  folderName: string,
+): void {
+  const servicesToGenerate = services.filter(service => !ctx.skipServices.has(service.apiClass))
+  if (servicesToGenerate.length === 0) {
+    console.log(' ⏭️  Skipping: all services excluded by skipServices')
+    return
+  }
+  for (const service of servicesToGenerate) {
+    writeServiceHooks(service, metadata, ctx, packageName, generatedDir, folderName)
+  }
+  const indexContent = generateIndexFile(servicesToGenerate, metadata, ctx.config)
+  writeFileSync(join(generatedDir, ctx.config.naming.indexFile), indexContent)
+}
+
+async function processVersionCore(
+  packageName: string,
+  pkgDir: string,
+  version: string,
+  ctx: GenerationContext,
+): Promise<void> {
+  const metadata = await loadMetadata(pkgDir, version, ctx.metadataFileName)
+  if (!metadata?.services) {
+    console.warn(`    ⚠️  Invalid metadata for ${packageName}/${version}, skipping`)
+    return
+  }
+  const { folderName, services } = metadata
+  const generatedDir = prepareGeneratedDir(ctx, folderName)
+  generateServiceHooks(services, metadata, ctx, packageName, generatedDir, folderName)
+  console.log(`✅ Generated hooks for ${folderName}`)
+}
+
+async function processVersion(
+  packageName: string,
+  pkgDir: string,
+  version: string,
+  ctx: GenerationContext,
+): Promise<void> {
+  if (ctx.skipVersions.has(`${packageName}@${version}`) || ctx.skipVersions.has(version)) {
+    console.log(`  ⏭️  Skipping ${packageName}/${version} (excluded by skipVersions)`)
+    return
+  }
+  try {
+    await processVersionCore(packageName, pkgDir, version, ctx)
+  } catch (error) {
+    console.error(`    ❌ Error loading ${packageName}/${version}/metadata:`, error)
+    throw error
+  }
+}
+
+async function processPackage(packageName: string, pkgDir: string, ctx: GenerationContext): Promise<void> {
+  if (ctx.skipPackages.has(packageName)) {
+    console.log(`⏭️ Skipping ${packageName} (excluded by skipPackages)`)
+    return
+  }
+  const versions = discoverVersions(pkgDir, ctx.metadataFileName)
+  if (versions.length === 0) {
+    console.log(` ⏭️ Skipping ${packageName} (no metadata found)`)
+    return
+  }
+  console.log(`  📦 ${packageName}: ${versions.length} version(s): ${versions.join(', ')}`)
+  for (const version of versions) {
+    await processVersion(packageName, pkgDir, version, ctx)
+  }
+}
+
+export async function generateFromMetadata(config: ReactQueriesConfig): Promise<void> {
+  const ctx: GenerationContext = {
+    config,
+    metadataFileName: config.naming.metadataFileName,
+    skipMethods: new Set(config.filters.skipMethods),
+    skipServices: new Set(config.filters.skipServices),
+    skipVersions: new Set(config.filters.skipVersions),
+    skipPackages: new Set(config.filters.skipPackages),
+    namespaceResolver: await buildNamespaceResolver(config),
+  }
+
+  const sdkPackages = discoverSdkPackages(config)
+  for (const [packageName, pkgDir] of sdkPackages) {
+    await processPackage(packageName, pkgDir, ctx)
   }
 
   console.log('🎉 Hook generation complete!')

--- a/tools/generate-react-queries/src/hook-generators.ts
+++ b/tools/generate-react-queries/src/hook-generators.ts
@@ -27,6 +27,16 @@ function collectNsImports(imports: Map<string, ResolvedNamespace>): ResolvedName
   return [...imports.values()].sort((a, b) => a.packageName.localeCompare(b.packageName))
 }
 
+type ResolvedNames = ReturnType<typeof resolveNames>
+
+function resolveApiNames(folderName: string, service: ServiceMetadata, config: ReactQueriesConfig) {
+  const apiImportName = `${folderName}${service.apiClass}`
+  const apiHookName = `${config.naming.hookPrefix}${capitalize(apiImportName)}`
+  const apiVarName = apiImportName.replace(/API$/, '')
+  const apiImportPath = `${config.imports.apiSdkPath}/${lowerCaseFirst(apiImportName)}`
+  return { apiImportName, apiHookName, apiVarName, apiImportPath }
+}
+
 /** Derive all naming conventions for a given method + service combination. */
 function resolveNames(
   method: QueryMethod,
@@ -38,11 +48,7 @@ function resolveNames(
 ) {
   const { folderName } = metadata
   const rawTypes = new Set(config.filters.rawTypes)
-
-  const apiImportName = `${folderName}${service.apiClass}`
-  const apiHookName = `${config.naming.hookPrefix}${capitalize(apiImportName)}`
-  const apiVarName = apiImportName.replace(/API$/, '')
-  const apiImportPath = `${config.imports.apiSdkPath}/${lowerCaseFirst(apiImportName)}`
+  const { apiHookName, apiVarName, apiImportPath } = resolveApiNames(folderName, service, config)
 
   const ns = capitalize(folderName)
   const selfNs: ResolvedNamespace = { packageName: sdkPackageName, ns }
@@ -112,6 +118,26 @@ export function generateQueryHook(
   })
 }
 
+function collectAllHookImports(
+  n: ResolvedNames,
+  method: QueryMethod,
+  sdkPackageName: string,
+  itemNsInfo: ResolvedNamespace,
+  rawItemType: string | undefined,
+): Map<string, ResolvedNamespace> {
+  const nsImports = new Map<string, ResolvedNamespace>()
+  if (!n.rawTypes.has(method.paramsType)) {
+    nsImports.set(sdkPackageName, n.selfNs)
+  }
+  if (!n.rawTypes.has(method.returnType)) {
+    nsImports.set(n.returnNsInfo.packageName, n.returnNsInfo)
+  }
+  if (rawItemType && !n.rawTypes.has(rawItemType)) {
+    nsImports.set(itemNsInfo.packageName, itemNsInfo)
+  }
+  return nsImports
+}
+
 /** Generate an "all" hook that fetches every page of a list method. */
 export function generateAllQueryHook(
   method: QueryMethod,
@@ -130,17 +156,7 @@ export function generateAllQueryHook(
   const rawItemType = method.listItemType
   const itemType = rawItemType ? nsType(itemNsInfo.ns, rawItemType, n.rawTypes) : n.returnType
 
-  // Collect namespace imports: params type, return type (if used), and list item type
-  const nsImports = new Map<string, ResolvedNamespace>()
-  if (!n.rawTypes.has(method.paramsType)) {
-    nsImports.set(sdkPackageName, n.selfNs)
-  }
-  if (!n.rawTypes.has(method.returnType)) {
-    nsImports.set(n.returnNsInfo.packageName, n.returnNsInfo)
-  }
-  if (rawItemType && !n.rawTypes.has(rawItemType)) {
-    nsImports.set(itemNsInfo.packageName, itemNsInfo)
-  }
+  const nsImports = collectAllHookImports(n, method, sdkPackageName, itemNsInfo, rawItemType)
 
   return renderHook({
     apiHookName: n.apiHookName,
@@ -218,6 +234,46 @@ export function generateReloadHook(
   })
 }
 
+function collectListExports(
+  method: QueryMethod,
+  serviceName: string,
+  config: ReactQueriesConfig,
+  baseName: string,
+): string[] {
+  const exports = [
+    `export { ${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery"`,
+  ]
+  if (!(config.filters.skipCursorAllHooks && method.paginationType === 'cursor')) {
+    exports.push(
+      `export { ${config.naming.hookPrefix}${serviceName}${baseName}AllQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}AllQuery"`,
+    )
+  }
+  return exports
+}
+
+function collectMethodExports(
+  method: QueryMethod,
+  serviceName: string,
+  config: ReactQueriesConfig,
+  skipMethods: Set<string>,
+): string[] {
+  if (skipMethods.has(method.methodName) || (config.filters.skipPrivateMethods && method.isPrivate)) return []
+  const baseName = capitalize(method.methodName)
+  const exports = [
+    `export { ${config.naming.hookPrefix}${serviceName}${baseName}Query } from "./${config.naming.hookPrefix}${serviceName}${baseName}Query"`,
+  ]
+  if (method.isList) {
+    exports.push(...collectListExports(method, serviceName, config, baseName))
+  }
+  if (method.hasWaiter && !config.filters.skipWaiters) {
+    const waiterName = `${config.naming.waiterPrefix}${capitalize(method.methodName.replace(/^get/, ''))}`
+    exports.push(
+      `export { ${config.naming.hookPrefix}${serviceName}${waiterName}Query } from "./${config.naming.hookPrefix}${serviceName}${waiterName}Query"`,
+    )
+  }
+  return exports
+}
+
 /** Generate the barrel index.ts that re-exports all hooks for a namespace. */
 export function generateIndexFile(
   services: ServiceMetadata[],
@@ -232,30 +288,7 @@ export function generateIndexFile(
     const serviceName = `${capitalize(folderName)}${service.apiClass}`
 
     for (const method of service.methods) {
-      if (!skipMethods.has(method.methodName) && !(config.filters.skipPrivateMethods && method.isPrivate)) {
-        const baseName = capitalize(method.methodName)
-        exports.push(
-          `export { ${config.naming.hookPrefix}${serviceName}${baseName}Query } from "./${config.naming.hookPrefix}${serviceName}${baseName}Query"`,
-        )
-
-        if (method.isList) {
-          exports.push(
-            `export { ${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery"`,
-          )
-          if (!(config.filters.skipCursorAllHooks && method.paginationType === 'cursor')) {
-            exports.push(
-              `export { ${config.naming.hookPrefix}${serviceName}${baseName}AllQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}AllQuery"`,
-            )
-          }
-        }
-
-        if (method.hasWaiter && !config.filters.skipWaiters) {
-          const waiterName = `${config.naming.waiterPrefix}${capitalize(method.methodName.replace(/^get/, ''))}`
-          exports.push(
-            `export { ${config.naming.hookPrefix}${serviceName}${waiterName}Query } from "./${config.naming.hookPrefix}${serviceName}${waiterName}Query"`,
-          )
-        }
-      }
+      exports.push(...collectMethodExports(method, serviceName, config, skipMethods))
     }
 
     exports.push(

--- a/tools/generate-react-queries/src/namespace-resolver.ts
+++ b/tools/generate-react-queries/src/namespace-resolver.ts
@@ -38,6 +38,46 @@ function normalizeNsPath(nsPath: string): string {
   return nsPath.replace(/^@scaleway\/sdk-/, '@scaleway-internal/sdk-')
 }
 
+function registerNsPath(
+  nsPath: string,
+  ownPathPrefix: string,
+  packageName: string,
+  ns: string,
+  resolver: Map<string, ResolvedNamespace>,
+): void {
+  const normalized = normalizeNsPath(nsPath)
+  if (!resolver.has(normalized) && normalized.startsWith(`${ownPathPrefix}/`)) {
+    resolver.set(normalized, { packageName, ns })
+  }
+}
+
+async function registerVersionNamespaces(
+  packageName: string,
+  pkgDir: string,
+  version: string,
+  metadataFileName: string,
+  ownPathPrefix: string,
+  resolver: Map<string, ResolvedNamespace>,
+): Promise<void> {
+  try {
+    const metadata = await loadMetadata(pkgDir, version, metadataFileName)
+    const ns = capitalize(metadata.folderName)
+
+    for (const service of metadata.services) {
+      for (const method of service.methods) {
+        for (const nsPath of [method.returnTypeNamespace, method.listItemTypeNamespace]) {
+          if (nsPath) registerNsPath(nsPath, ownPathPrefix, packageName, ns, resolver)
+        }
+      }
+    }
+  } catch (error) {
+    console.warn(
+      `⚠️  Failed to load metadata for ${packageName}/${version}:`,
+      error instanceof Error ? error.message : error,
+    )
+  }
+}
+
 /**
  * Build a map of all known namespace paths → { packageName, ns }.
  *
@@ -65,34 +105,7 @@ export async function buildNamespaceResolver(config: ReactQueriesConfig): Promis
     const ownPathPrefix = normalizePackagePath(packageName)
 
     for (const version of versions) {
-      try {
-        const metadata = await loadMetadata(pkgDir, version, metadataFileName)
-        const ns = capitalize(metadata.folderName)
-
-        for (const service of metadata.services) {
-          for (const method of service.methods) {
-            for (const nsPath of [method.returnTypeNamespace, method.listItemTypeNamespace]) {
-              if (nsPath) {
-                const normalized = normalizeNsPath(nsPath)
-                // Only register the path as owned by this package when it
-                // actually matches this package's own namespace prefix.
-                // Cross-package references (nsPath belongs to a different
-                // package) are left for that package to claim when it is
-                // iterated; if no package claims them, resolveTypeNamespace
-                // falls back to the current package's namespace.
-                if (!resolver.has(normalized) && normalized.startsWith(`${ownPathPrefix}/`)) {
-                  resolver.set(normalized, { packageName, ns })
-                }
-              }
-            }
-          }
-        }
-      } catch (error) {
-        console.warn(
-          `⚠️  Failed to load metadata for ${packageName}/${version}:`,
-          error instanceof Error ? error.message : error,
-        )
-      }
+      await registerVersionNamespaces(packageName, pkgDir, version, metadataFileName, ownPathPrefix, resolver)
     }
   }
 

--- a/tools/generate-react-queries/src/package-exports.ts
+++ b/tools/generate-react-queries/src/package-exports.ts
@@ -26,6 +26,27 @@ function removeSrcFromPath(path: string): string {
     .replace(/^src[\\/]/, '')
 }
 
+function buildNamespaceExports(
+  allNamespaces: string[],
+  config: ReactQueriesConfig,
+  cleanDirName: string,
+  pathKey: 'generatedPath' | 'customPath',
+  keySuffix = '',
+): Record<string, ExportEntry> {
+  const subPath = config[pathKey]
+  const directories = allNamespaces.filter(namespace =>
+    existsSync(join(config.outputDir, namespace, subPath, config.naming.indexFile)),
+  )
+  const prefix = cleanDirName ? `${cleanDirName}/` : ''
+  return directories.reduce<Record<string, ExportEntry>>((acc, namespace) => {
+    acc[`./${namespace}${keySuffix}`] = {
+      default: `./dist/${prefix}${namespace}/${subPath}/index.js`,
+      types: `./dist/${prefix}${namespace}/${subPath}/index.d.ts`,
+    }
+    return acc
+  }, {})
+}
+
 export function updatePackageJsonExports(config: ReactQueriesConfig): void {
   const allNamespaces = readdirSync(resolve('./', config.outputDir), {
     withFileTypes: true,
@@ -33,34 +54,10 @@ export function updatePackageJsonExports(config: ReactQueriesConfig): void {
     .map(file => (file.isDirectory() ? file.name : ''))
     .filter(fileName => fileName !== '')
 
-  const generatedNamespaceDirectories = allNamespaces.filter(namespace =>
-    existsSync(join(config.outputDir, namespace, config.generatedPath, config.naming.indexFile)),
-  )
-  const customNamespaceDirectories = allNamespaces.filter(namespace =>
-    existsSync(join(config.outputDir, namespace, config.customPath, config.naming.indexFile)),
-  )
-
   const cleanDirName = removeSrcFromPath(config.outputDir)
 
-  const generatedExportsConfig: Record<string, ExportEntry> = generatedNamespaceDirectories.reduce<
-    Record<string, ExportEntry>
-  >((acc, namespace) => {
-    acc[`./${namespace}`] = {
-      default: `./dist/${cleanDirName ? `${cleanDirName}/` : ''}${namespace}/${config.generatedPath}/index.js`,
-      types: `./dist/${cleanDirName ? `${cleanDirName}/` : ''}${namespace}/${config.generatedPath}/index.d.ts`,
-    }
-    return acc
-  }, {})
-
-  const customExportsConfig: Record<string, ExportEntry> = customNamespaceDirectories.reduce<
-    Record<string, ExportEntry>
-  >((acc, namespace) => {
-    acc[`./${namespace}/custom`] = {
-      default: `./dist/${cleanDirName ? `${cleanDirName}/` : ''}${namespace}/${config.customPath}/index.js`,
-      types: `./dist/${cleanDirName ? `${cleanDirName}/` : ''}${namespace}/${config.customPath}/index.d.ts`,
-    }
-    return acc
-  }, {})
+  const generatedExportsConfig = buildNamespaceExports(allNamespaces, config, cleanDirName, 'generatedPath')
+  const customExportsConfig = buildNamespaceExports(allNamespaces, config, cleanDirName, 'customPath', '/custom')
 
   const otherStaticExport: Record<string, ExportEntry> = {
     './mocks*': {

--- a/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
@@ -41,14 +41,11 @@ function discoverSdkPackages(packageNameFilter: string): Map<string, string> {
       }
     : {}
 
-  const packages = new Map<string, string>()
-  for (const [name] of Object.entries(allDeps)) {
-    if (name.startsWith(packageNameFilter)) {
-      packages.set(name, name)
-    }
-  }
-
-  return packages
+  return new Map(
+    Object.keys(allDeps)
+      .filter(name => name.startsWith(packageNameFilter))
+      .map(name => [name, name] as const),
+  )
 }
 
 async function loadVersions(packageName: string): Promise<string[]> {
@@ -66,25 +63,99 @@ async function loadVersions(packageName: string): Promise<string[]> {
   }
 }
 
+async function loadMetadataFromFallback(packageName: string, version: string): Promise<Metadata> {
+  const pkgDir = join(dirname(resolve('package.json')), 'node_modules', packageName)
+  const distMetadataPath = join(pkgDir, 'dist', version, 'metadata.gen.js')
+  const metadataModule = await import(distMetadataPath)
+  return (metadataModule as { queriesMetadata: Metadata }).queriesMetadata
+}
+
 async function loadMetadata(packageName: string, version: string): Promise<Metadata | null> {
   try {
-    // Try the exported path first
     try {
       const resolvedPath = require.resolve(`${packageName}/${version}/metadata`)
       const metadataModule = await import(resolvedPath)
       return (metadataModule as { queriesMetadata: Metadata }).queriesMetadata
     } catch {
       stdout.write(`⚠️  Error loading metadata from ${packageName}/${version}/metadata \n Using dist fallback \n`)
-      // Fallback: construct path from node_modules
-      const pkgDir = join(dirname(resolve('package.json')), 'node_modules', packageName)
-      const distMetadataPath = join(pkgDir, 'dist', version, 'metadata.gen.js')
-      const metadataModule = await import(distMetadataPath)
-      return (metadataModule as { queriesMetadata: Metadata }).queriesMetadata
+      return await loadMetadataFromFallback(packageName, version)
     }
   } catch (error) {
     stdout.write(`⚠️  Error loading metadata from ${packageName}/${version}/metadata: ${error}\n`)
     return null
   }
+}
+
+async function processVersion(
+  packageName: string,
+  version: string,
+  servicesToSkip: Set<string>,
+  isVersionSkipped: (packageName: string, version: string) => boolean,
+): Promise<ProcessedMetadata | null> {
+  if (isVersionSkipped(packageName, version)) {
+    stdout.write(`⚠️  Skipping ${packageName}/${version}: excluded by skipVersions\n`)
+    return null
+  }
+  const metadata = await loadMetadata(packageName, version)
+  if (!metadata) {
+    stdout.write(`⚠️  Skipping ${packageName}/${version}: no queriesMetadata found\n`)
+    return null
+  }
+  const namespace = metadata.folderName || metadata.namespace
+  const apis = metadata.services
+    .filter((service: { apiClass: string }) => !servicesToSkip.has(service.apiClass))
+    .map((service: { apiClass: string }) => service.apiClass)
+    .filter((apiClass: string) => apiClass && apiClass.length > 0)
+  return apis.length > 0 ? { [namespace]: { packageName, apis } } : null
+}
+
+async function processPackageVersions(
+  packageName: string,
+  servicesToSkip: Set<string>,
+  isVersionSkipped: (packageName: string, version: string) => boolean,
+): Promise<ProcessedMetadata> {
+  const versions = await loadVersions(packageName)
+  if (versions.length === 0) {
+    stdout.write(`⚠️  Skipping ${packageName}: no versions with metadata found\n`)
+    return {}
+  }
+  let pkgResult: ProcessedMetadata = {}
+  for (const version of versions) {
+    const versionResult = await processVersion(packageName, version, servicesToSkip, isVersionSkipped)
+    if (versionResult) pkgResult = { ...pkgResult, ...versionResult }
+  }
+  return pkgResult
+}
+
+function setupGenerateAPI(
+  dirGenName: string,
+  packageNameFilter: string,
+  skipServices: string[],
+  skipVersions: string[],
+) {
+  const dir = join(directoryOfSrcFolder, dirGenName)
+  mkdirSync(dir, { recursive: true })
+  const sdkPackages = discoverSdkPackages(packageNameFilter)
+  if (sdkPackages.size === 0) stdout.write('⚠️  No SDK packages found in dependencies\n')
+  const skipPackages = new Set(['@scaleway/sdk-test', '@scaleway/sdk-std'])
+  const servicesToSkip = new Set(skipServices)
+  const versionsToSkip = new Set(skipVersions)
+  const isVersionSkipped = (packageName: string, version: string): boolean =>
+    versionsToSkip.has(`${packageName}@${version}`) || versionsToSkip.has(version)
+  return { dir, sdkPackages, skipPackages, servicesToSkip, isVersionSkipped }
+}
+
+async function processSdkPackage(
+  packageName: string,
+  skipPackages: Set<string>,
+  servicesToSkip: Set<string>,
+  isVersionSkipped: (packageName: string, version: string) => boolean,
+): Promise<ProcessedMetadata> {
+  if (skipPackages.has(packageName)) {
+    stdout.write(`⚠️  Skipping ${packageName}: excluded package\n`)
+    return {}
+  }
+  return await processPackageVersions(packageName, servicesToSkip, isVersionSkipped)
 }
 
 export const generateAPI = async ({
@@ -100,69 +171,18 @@ export const generateAPI = async ({
   skipServices?: string[]
   skipVersions?: string[]
 }) => {
+  const { dir, sdkPackages, skipPackages, servicesToSkip, isVersionSkipped } = setupGenerateAPI(
+    dirGenName,
+    packageNameFilter,
+    skipServices,
+    skipVersions,
+  )
   let result: ProcessedMetadata = {}
-
-  const dir = join(directoryOfSrcFolder, dirGenName)
-
-  // Create directory if it doesn't exist (don't delete existing files)
-  mkdirSync(dir, { recursive: true })
-
-  const sdkPackages = discoverSdkPackages(packageNameFilter)
-
-  if (sdkPackages.size === 0) {
-    stdout.write('⚠️  No SDK packages found in dependencies\n')
-  }
-
-  const skipPackages = new Set(['@scaleway/sdk-test', '@scaleway/sdk-std'])
-  const servicesToSkip = new Set(skipServices)
-  const versionsToSkip = new Set(skipVersions)
-
-  const isVersionSkipped = (packageName: string, version: string): boolean =>
-    versionsToSkip.has(`${packageName}@${version}`) || versionsToSkip.has(version)
-
   for (const [packageName] of sdkPackages) {
-    if (skipPackages.has(packageName)) {
-      stdout.write(`⚠️  Skipping ${packageName}: excluded package\n`)
-    } else {
-      const versions = await loadVersions(packageName)
-
-      if (versions.length === 0) {
-        stdout.write(`⚠️  Skipping ${packageName}: no versions with metadata found\n`)
-      } else {
-        for (const version of versions) {
-          if (isVersionSkipped(packageName, version)) {
-            stdout.write(`⚠️  Skipping ${packageName}/${version}: excluded by skipVersions\n`)
-          } else {
-            const metadata = await loadMetadata(packageName, version)
-
-            if (!metadata) {
-              stdout.write(`⚠️  Skipping ${packageName}/${version}: no queriesMetadata found\n`)
-            } else {
-              const namespace = metadata.folderName || metadata.namespace
-              const apis = metadata.services
-                .filter((service: { apiClass: string }) => !servicesToSkip.has(service.apiClass))
-                .map((service: { apiClass: string }) => service.apiClass)
-                .filter((apiClass: string) => apiClass && apiClass.length > 0)
-
-              if (apis.length > 0) {
-                result = {
-                  ...result,
-                  [namespace]: {
-                    packageName,
-                    apis,
-                  },
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    result = { ...result, ...(await processSdkPackage(packageName, skipPackages, servicesToSkip, isVersionSkipped)) }
   }
-
   emitFiles({ res: result, sourceFolderGen: dir, sdkFactoryPath })
   generateType(result)
-
   exec('cd ../.. && pnpm run format').on('error', () => {
     stdout.write('❌ Error during format !\n')
     exit(1)

--- a/tools/generate-react-sdk/src/generateAPI/generateType.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generateType.ts
@@ -3,30 +3,34 @@ import { join, resolve } from 'node:path'
 import type { ProcessedMetadata } from '../metadata-types.ts'
 import { lowerCaseFirstLetter } from './helpers.ts'
 
-export const generateType = (res: ProcessedMetadata) => {
-  const filename = 'types.generated.ts'
-  const template = ['//this file is generated \n\n']
-
-  // import types
-  for (const [name, { packageName }] of Object.entries(res)) {
+function buildImportLines(res: ProcessedMetadata): string[] {
+  return Object.entries(res).map(([name, { packageName }]) => {
     const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1)
-    const imp = `import type { ${capitalizedName} } from "${packageName}"\n`
-    template.push(imp)
-  }
+    return `import type { ${capitalizedName} } from "${packageName}"\n`
+  })
+}
 
-  // export
-  template.push('\n export type APISdk = {\n')
-
+function buildExportLines(res: ProcessedMetadata): string[] {
+  const lines: string[] = []
   for (const [name, { apis }] of Object.entries(res)) {
     const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1)
     for (const api of apis) {
       const key = `${lowerCaseFirstLetter(name + api.replace('API', ''))}`
       const type = `${capitalizedName}.${api}`
-
-      template.push(`${key}:${type},\n`)
+      lines.push(`${key}:${type},\n`)
     }
   }
-  template.push('\n}')
-  const src = join(resolve('./src/'), filename)
-  writeFileSync(src, template.join('').toString())
+  return lines
+}
+
+export const generateType = (res: ProcessedMetadata) => {
+  const content = [
+    '//this file is generated \n\n',
+    ...buildImportLines(res),
+    '\n export type APISdk = {\n',
+    ...buildExportLines(res),
+    '\n}',
+  ].join('')
+  const src = join(resolve('./src/'), 'types.generated.ts')
+  writeFileSync(src, content)
 }

--- a/tools/generate-react-sdk/src/parseArgsCLI.ts
+++ b/tools/generate-react-sdk/src/parseArgsCLI.ts
@@ -1,32 +1,47 @@
 /* eslint-disable no-console */
 // Parse CLI arguments
 
+type ParsedArg = { key: string; value: string | boolean; consumedNext: boolean }
+
+function parseSingleArg(arg: string, nextArg: string | undefined): ParsedArg | null {
+  if (!arg.startsWith('--')) return null
+
+  const parts = arg.slice(2).split('=')
+  const key = parts[0]
+  let value: string | boolean = parts.length > 1 ? (parts[1] as string) : true
+  let consumedNext = false
+
+  if (value === true && nextArg && !nextArg.startsWith('--')) {
+    value = nextArg
+    consumedNext = true
+  }
+
+  return key ? { key, value, consumedNext } : null
+}
+
+function applyParsedArg(
+  parsed: ParsedArg,
+  requiresValueArgs: string[] | undefined,
+  cliArgs: Record<string, string | boolean>,
+): void {
+  if (requiresValueArgs?.includes(parsed.key) && (parsed.value === true || parsed.value === undefined)) {
+    console.log(`⚠️  Warning: --${parsed.key} requires a value, using default`)
+  } else {
+    cliArgs[parsed.key] = parsed.value
+  }
+}
+
 export const parseArgsCLI = <T extends string[]>({ requiresValueArgs }: { requiresValueArgs?: T }) => {
   const args = process.argv.slice(2)
   const cliArgs: Record<string, string | boolean> = {}
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
-    if (arg?.startsWith('--')) {
-      const parts = arg.slice(2).split('=')
-      const key = parts[0]
-      let value = parts.length > 1 ? parts[1] : true
-
-      // Check if the next argument is a value for this flag (handles --arg value format)
-      if (value === true && i + 1 < args.length && args[i + 1] && !args[i + 1]?.startsWith('--')) {
-        value = args[i + 1]
-        i++ // Skip the next argument since we've consumed it
-      }
-
-      if (key) {
-        // For arguments that require values, if no value is provided, skip them or use default
-        if (requiresValueArgs?.includes(key) && (value === true || value === undefined)) {
-          console.log(`⚠️  Warning: --${key} requires a value, using default`)
-        } else {
-          cliArgs[key] = value as string | boolean
-        }
-      }
-    }
+    const nextArg = i + 1 < args.length ? args[i + 1] : undefined
+    const parsed = arg?.startsWith('--') ? parseSingleArg(arg, nextArg) : null
+    if (!parsed) continue
+    if (parsed.consumedNext) i++
+    applyParsedArg(parsed, requiresValueArgs, cliArgs)
   }
   return { cliArgs }
 }

--- a/tools/pnpm-auto-release/src/cli.ts
+++ b/tools/pnpm-auto-release/src/cli.ts
@@ -16,6 +16,17 @@ import {
 
 const { log: logger } = console
 
+type WorkspacePackage = ReturnType<typeof listWorkspacePackages>[number]
+
+type ReleaseOptions = {
+  dryRun: boolean
+  skipPublish: boolean
+  skipPush: boolean
+  byCommit: boolean
+  ghRelease: boolean
+  registry?: string
+}
+
 const HELP = `Usage: release [options]
 
 Bump and publish changed packages in the monorepo.
@@ -39,7 +50,7 @@ Environment variables for registry auth:
   GH_TOKEN               GitHub token for creating releases (required with --gh-release)
 `
 
-function main() {
+function parseReleaseArgs(): ReleaseOptions | null {
   const { values } = parseArgs({
     args: process.argv.slice(2),
     options: {
@@ -52,119 +63,104 @@ function main() {
       help: { type: 'boolean', short: 'h', default: false },
     },
   })
-
   if (values.help) {
     logger(HELP)
-    return
+    return null
   }
-
-  const dryRun = values['dry-run'] === true
-  const skipPublish = values['skip-publish'] === true
-  const skipPush = values['skip-push'] === true
-  const byCommit = values['by-commit'] === true
-  const ghRelease = values['gh-release'] === true
-  const registry = values.registry
-
-  if (ghRelease) {
+  if (values['gh-release'] === true) {
     const ghToken = process.env['GH_TOKEN'] || process.env['GITHUB_TOKEN']
     if (!ghToken) {
       throw new Error('GH_TOKEN environment variable is required for creating GitHub releases')
     }
   }
+  return {
+    dryRun: values['dry-run'] === true,
+    skipPublish: values['skip-publish'] === true,
+    skipPush: values['skip-push'] === true,
+    byCommit: values['by-commit'] === true,
+    ghRelease: values['gh-release'] === true,
+    registry: values.registry,
+  }
+}
 
-  const root = findWorkspaceRoot(process.cwd())
+function gatherAffectedPackages(root: string, dryRun: boolean): { affected: WorkspacePackage[]; range: string } {
   const packages = listWorkspacePackages(root)
-
-  const lastSha =
-    exec(`git log --grep="^${RELEASE_SUBJECT}" -1 --format="%H"`, {
-      cwd: root,
-    }) || null
+  const lastSha = exec(`git log --grep="^${RELEASE_SUBJECT}" -1 --format="%H"`, { cwd: root }) || null
   const range = lastSha ? `${lastSha}..HEAD` : 'HEAD~50..HEAD'
   const changedFiles = exec(`git diff --name-only ${range}`, { cwd: root }).split('\n').filter(Boolean)
-
   const affected = packages.filter(pkg => !pkg.private && changedFiles.some(f => f.startsWith(`${pkg.relativePath}/`)))
-
   logger(`[release] ${affected.length} packages to bump (dryRun=${dryRun})`)
   for (const pkg of affected) logger(`  - ${pkg.name}: ${pkg.version}`)
+  return { affected, range }
+}
 
-  if (dryRun || affected.length === 0) return
+function writeNpmrcAuth(root: string, registry: string): void {
+  const user = process.env['NPM_REGISTRY_USER']
+  const passwd = process.env['NPM_REGISTRY_PASSWD']
+  if (!user || !passwd) return
+  const host = registry.replace(/^https?:\/\//, '')
+  const auth = Buffer.from(`${user}:${passwd}`).toString('base64')
+  appendFileSync(join(root, '.npmrc'), `\n//${host}/:_auth=${auth}\n`)
+  logger(`[release] authenticated to ${host}`)
+}
 
-  createChangesets({
-    root,
-    range,
-    packages: affected,
-    byCommit,
-    defaultSummary: CHANGESET_MESSAGE,
-  })
+function publishPackages(root: string, options: ReleaseOptions): void {
+  if (options.skipPublish) return
+  if (options.registry) writeNpmrcAuth(root, options.registry)
+  const flag = options.registry ? ` --registry ${options.registry}` : ''
+  exec(`pnpm publish -r --no-git-checks --access public${flag}`, { cwd: root, stdio: 'inherit' })
+  logger('[release] published')
+}
 
-  // Bump versions — pnpm handles dependency propagation.
-  // In recursive mode pnpm never creates git commits/tags itself, so the
-  // working tree is left dirty for us to commit explicitly below — but only
-  // after publish has succeeded, so a registry failure leaves the remote
-  // untouched and the run can be retried from a pristine state.
-  exec('pnpm version -r --no-git-checks --tag-version-prefix ""', {
-    cwd: root,
-    stdio: 'inherit',
-  })
+function bumpAndPublish(
+  root: string,
+  options: ReleaseOptions,
+  affected: WorkspacePackage[],
+  range: string,
+): WorkspacePackage[] {
+  createChangesets({ root, range, packages: affected, byCommit: options.byCommit, defaultSummary: CHANGESET_MESSAGE })
+  exec('pnpm version -r --no-git-checks --tag-version-prefix ""', { cwd: root, stdio: 'inherit' })
   exec('rm -rf .changeset/*', { cwd: root })
-
   const updated = listWorkspacePackages(root)
+  publishPackages(root, options)
+  return updated
+}
 
-  // Publish BEFORE committing/tagging/pushing. If publish fails (registry
-  // down, auth expired, network, version already exists, ...) we abort and
-  // leave the remote untouched — no tags pointing at unpublished versions.
-  // `pnpm publish -r` skips versions already on the registry, so retries
-  // are idempotent and only publish what's missing.
-  if (!skipPublish) {
-    const user = process.env['NPM_REGISTRY_USER']
-    const passwd = process.env['NPM_REGISTRY_PASSWD']
-    if (registry && user && passwd) {
-      const host = registry.replace(/^https?:\/\//, '')
-      const auth = Buffer.from(`${user}:${passwd}`).toString('base64')
-      const npmrcPath = join(root, '.npmrc')
-      appendFileSync(npmrcPath, `\n//${host}/:_auth=${auth}\n`)
-      logger(`[release] authenticated to ${host}`)
-    }
-    const flag = registry ? ` --registry ${registry}` : ''
-    exec(`pnpm publish -r --no-git-checks --access public${flag}`, {
-      cwd: root,
-      stdio: 'inherit',
-    })
-    logger('[release] published')
+function pushRelease(root: string, skipPush: boolean, newTags: string[]): void {
+  if (skipPush) return
+  exec('git push origin HEAD --no-verify', { cwd: root })
+  for (const tag of newTags) {
+    exec(`git push origin "refs/tags/${tag}" --no-verify`, { cwd: root })
   }
+  logger('[release] pushed')
+}
 
-  // Commit and tag — only reached if publish succeeded (or --skip-publish).
+function commitTagAndPush(
+  root: string,
+  options: ReleaseOptions,
+  affected: WorkspacePackage[],
+  updated: WorkspacePackage[],
+): void {
   exec('git add -A', { cwd: root })
   exec('git commit -m "chore(release): publish" --no-verify', { cwd: root })
-
-  const newTags = createTags({
-    root,
-    affectedPackages: affected,
-    updatedPackages: updated,
-  })
-
-  // Create GitHub releases
-  if (ghRelease) {
-    createGithubReleases({
-      root,
-      affectedPackages: affected,
-      updatedPackages: updated,
-    })
+  const newTags = createTags({ root, affectedPackages: affected, updatedPackages: updated })
+  if (options.ghRelease) {
+    createGithubReleases({ root, affectedPackages: affected, updatedPackages: updated })
     logger('[release] github releases created')
   }
+  pushRelease(root, options.skipPush, newTags)
+}
 
-  // Push
-  if (!skipPush) {
-    // Push the branch first, then each new tag individually. Pushing tags one
-    // at a time (rather than `--tags`) means a tag that already exists on the
-    // remote no longer fails the whole push on retried runs.
-    exec('git push origin HEAD --no-verify', { cwd: root })
-    for (const tag of newTags) {
-      exec(`git push origin "refs/tags/${tag}" --no-verify`, { cwd: root })
-    }
-    logger('[release] pushed')
-  }
+function main() {
+  const options = parseReleaseArgs()
+  if (!options) return
 
+  const root = findWorkspaceRoot(process.cwd())
+  const { affected, range } = gatherAffectedPackages(root, options.dryRun)
+  if (options.dryRun || affected.length === 0) return
+
+  const updated = bumpAndPublish(root, options, affected, range)
+  commitTagAndPush(root, options, affected, updated)
   logger('[release] done.')
 }
 

--- a/tools/pnpm-auto-release/src/utils.ts
+++ b/tools/pnpm-auto-release/src/utils.ts
@@ -48,6 +48,29 @@ export const listWorkspacePackages = (root: string) => {
     }))
 }
 
+function tagExists(root: string, tag: string): boolean {
+  let localExists = false
+  try {
+    exec(`git rev-parse -q --verify refs/tags/${tag}`, { cwd: root })
+    localExists = true
+  } catch {
+    localExists = false
+  }
+  const remoteExists = exec(`git ls-remote --tags origin "refs/tags/${tag}"`, { cwd: root }).length > 0
+  return localExists || remoteExists
+}
+
+function createTagForPackage(root: string, pkg: Package, newPkg: Package, newTags: string[]): void {
+  const tag = `${pkg.name}@${newPkg.version}`
+  if (tagExists(root, tag)) {
+    logger(`[release] tag already exists, skipping: ${tag}`)
+    return
+  }
+  exec(`git tag "${tag}" -m "${tag}"`, { cwd: root })
+  newTags.push(tag)
+  logger(`[release] tag: ${tag}`)
+}
+
 export const createTags = ({
   root,
   affectedPackages,
@@ -60,29 +83,24 @@ export const createTags = ({
   const newTags: string[] = []
   for (const pkg of affectedPackages) {
     const newPkg = updatedPackages.find(({ name }) => name === pkg.name)
-    if (newPkg) {
-      const tag = `${pkg.name}@${newPkg.version}`
-      // Skip tags that already exist locally or on the remote. Retried runs
-      // must not recreate tags for already-released versions (pushing them
-      // would fail with "tag already exists").
-      let localExists = false
-      try {
-        exec(`git rev-parse -q --verify refs/tags/${tag}`, { cwd: root })
-        localExists = true
-      } catch {
-        localExists = false
-      }
-      const remoteExists = exec(`git ls-remote --tags origin "refs/tags/${tag}"`, { cwd: root }).length > 0
-      if (localExists || remoteExists) {
-        logger(`[release] tag already exists, skipping: ${tag}`)
-      } else {
-        exec(`git tag "${tag}" -m "${tag}"`, { cwd: root })
-        newTags.push(tag)
-        logger(`[release] tag: ${tag}`)
-      }
-    }
+    if (newPkg) createTagForPackage(root, pkg, newPkg, newTags)
   }
   return newTags
+}
+
+function createReleaseForPackage(root: string, pkg: Package, newPkg: Package): void {
+  const tag = `${pkg.name}@${newPkg.version}`
+  const releaseNotes = `Release ${tag}`
+  try {
+    exec(`gh release view ${tag} --repo ${getRepoFromRemote(root)} >/dev/null 2>&1`, { cwd: root })
+    logger(`[release] github release already exists: ${tag}`)
+  } catch {
+    exec(
+      `echo "${releaseNotes}" | gh release create ${tag} --title ${tag} --notes-file - --repo ${getRepoFromRemote(root)}`,
+      { cwd: root },
+    )
+    logger(`[release] github release created: ${tag}`)
+  }
 }
 
 export const createGithubReleases = ({
@@ -101,23 +119,7 @@ export const createGithubReleases = ({
 
   for (const pkg of affectedPackages) {
     const newPkg = updatedPackages.find(({ name }) => name === pkg.name)
-    if (newPkg) {
-      const tag = `${pkg.name}@${newPkg.version}`
-      const releaseNotes = `Release ${tag}`
-
-      try {
-        exec(`gh release view ${tag} --repo ${getRepoFromRemote(root)} >/dev/null 2>&1`, { cwd: root })
-        logger(`[release] github release already exists: ${tag}`)
-      } catch {
-        exec(
-          `echo "${releaseNotes}" | gh release create ${tag} --title ${tag} --notes-file - --repo ${getRepoFromRemote(root)}`,
-          {
-            cwd: root,
-          },
-        )
-        logger(`[release] github release created: ${tag}`)
-      }
-    }
+    if (newPkg) createReleaseForPackage(root, pkg, newPkg)
   }
 }
 
@@ -136,6 +138,21 @@ const createChangesetForPackages = (root: string, packages: Package[], summary: 
     cwd: root,
   })
   logger(`changeset ${summary} ${names}`)
+}
+
+function processCommit(root: string, line: string, packages: Package[], defaultSummary: string): void {
+  const [sha, subject] = line.split('\u001F')
+  if (!sha) return
+  const changedFiles = exec(`git diff-tree --no-commit-id --name-only -r ${sha}`, { cwd: root })
+    .split('\n')
+    .filter(Boolean)
+  const affected = packages.filter(
+    pkg => pkg.relativePath && changedFiles.some(f => f.startsWith(`${pkg.relativePath}/`)),
+  )
+  if (affected.length > 0) {
+    createChangesetForPackages(root, affected, subject || defaultSummary)
+    logger(`[release] changeset (${sha.slice(0, 7)} -> ${affected.length} pkg)`)
+  }
 }
 
 export const createChangesets = ({
@@ -160,20 +177,6 @@ export const createChangesets = ({
   const commits = exec(`git log ${range} --format="%H%x1F%s" --no-merges`, { cwd: root })
 
   for (const line of commits.split('\n').filter(Boolean)) {
-    const [sha, subject] = line.split('\u001F')
-    if (sha) {
-      const changedFiles = exec(`git diff-tree --no-commit-id --name-only -r ${sha}`, { cwd: root })
-        .split('\n')
-        .filter(Boolean)
-
-      const affected = packages.filter(
-        pkg => pkg.relativePath && changedFiles.some(f => f.startsWith(`${pkg.relativePath}/`)),
-      )
-
-      if (affected.length > 0) {
-        createChangesetForPackages(root, affected, subject || defaultSummary)
-        logger(`[release] changeset (${sha.slice(0, 7)} -> ${affected.length} pkg)`)
-      }
-    }
+    processCommit(root, line, packages, defaultSummary)
   }
 }


### PR DESCRIPTION
Closes #3351

Extract helper functions from large functions to comply with the `eslint/max-statements` rule (max 10 statements), then remove the rule from `oxlint.config.ts`.

Files refactored:
- `tools/generate-packages/src/commands/deps.ts`
- `tools/generate-packages/src/commands/packages.ts`
- `tools/generate-packages/src/commands/sdk.ts`
- `tools/generate-packages/src/commands/setup.ts`
- `tools/generate-react-queries/src/discover.ts`
- `tools/generate-react-queries/src/generate.ts`
- `tools/generate-react-queries/src/hook-generators.ts`
- `tools/generate-react-queries/src/namespace-resolver.ts`
- `tools/generate-react-queries/src/package-exports.ts`
- `tools/generate-react-sdk/src/generateAPI/generate-metadata.ts`
- `tools/generate-react-sdk/src/generateAPI/generateType.ts`
- `tools/generate-react-sdk/src/parseArgsCLI.ts`
- `tools/pnpm-auto-release/src/cli.ts`
- `tools/pnpm-auto-release/src/utils.ts`