### PR TITLE
fix(oxlint): fix unicorn/catch-error-name violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -25,7 +25,6 @@ export default defineConfig({
     'eslint/no-console': 'warn',
     'eslint/no-unused-vars': 'warn',
     'eslint/max-statements': 'warn',
-    'unicorn/catch-error-name': 'warn',
     'unicorn/explicit-length-check': 'warn',
     // TODO: new errors from @scaleway/oxlint-config 1.x upgrade — fix later
     'eslint/curly': 'warn',

--- a/tools/generate-react-queries/src/namespace-resolver.ts
+++ b/tools/generate-react-queries/src/namespace-resolver.ts
@@ -87,10 +87,10 @@ export async function buildNamespaceResolver(config: ReactQueriesConfig): Promis
             }
           }
         }
-      } catch (err) {
+      } catch (error) {
         console.warn(
           `⚠️  Failed to load metadata for ${packageName}/${version}:`,
-          err instanceof Error ? err.message : err,
+          error instanceof Error ? error.message : error,
         )
       }
     }


### PR DESCRIPTION
## Summary

Fix all violations of the `unicorn/catch-error-name` rule and remove it from `oxlint.config.ts`.

## Changes

- Renamed catch parameter `err` → `error` in `tools/generate-react-queries/src/namespace-resolver.ts`
- Removed the `unicorn/catch-error-name` rule from `oxlint.config.ts`

## Verification

- `pnpm lint` passes
- `pnpm typecheck` passes

Closes #3352