### PR TITLE
fix(oxlint): fix unicorn/explicit-length-check violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
     'typescript/no-unsafe-assignment': 'warn',
     'eslint/no-console': 'warn',
     'eslint/max-statements': 'warn',
-    'unicorn/explicit-length-check': 'warn',
     // TODO: new errors from @scaleway/oxlint-config 1.x upgrade — fix later
     'eslint/curly': 'warn',
     'eslint/default-case': 'warn',

--- a/tools/generate-packages/src/commands/setup.ts
+++ b/tools/generate-packages/src/commands/setup.ts
@@ -27,7 +27,7 @@ export type SetupOptions = {
 function walkHasGenFiles(root: string): boolean {
   if (!existsSync(root)) return false
   const stack = [root]
-  while (stack.length) {
+  while (stack.length > 0) {
     const p = stack.pop()
     if (!p) break
     const st = statSync(p)
@@ -76,7 +76,7 @@ export const setup = async ({
     .filter(p => p.hasGenFiles && !p.hasPackageJson)
 
   console.log(`📦 New products: ${newProducts.length}`)
-  if (newProducts.length) newProducts.forEach(p => console.log(`  - ${p.name}`))
+  if (newProducts.length > 0) newProducts.forEach(p => console.log(`  - ${p.name}`))
 
   if (newProducts.length === 0) {
     console.log('✅ No new products to configure')


### PR DESCRIPTION
Part of the [Oxlint v1](https://github.com/scaleway/scaleway-sdk-js/milestone/1) effort to clean up the warning rules in `oxlint.config.ts`.

## Rule

`unicorn/explicit-length-check`

**Documentation:** https://oxc.rs/docs/guide/usage/linter/rules//unicorn/explicit-length-check

## Changes

- Fixed 2 violations in `tools/generate-packages/src/commands/setup.ts`:
  - `while (stack.length)` → `while (stack.length > 0)`
  - `if (newProducts.length)` → `if (newProducts.length > 0)`
- Removed `unicorn/explicit-length-check` rule from `oxlint.config.ts`
- `pnpm lint` and `pnpm typecheck` pass

Closes #3353