### PR TITLE
fix(oxlint): enable eslint/prefer-named-capture-group as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -33,7 +33,6 @@ export default defineConfig({
     'eslint/no-use-before-define': 'warn',
     'eslint/no-useless-assignment': 'warn',
     'eslint/prefer-destructuring': 'warn',
-    'eslint/prefer-named-capture-group': 'warn',
     'eslint/prefer-template': 'warn',
     'eslint/require-unicode-regexp': 'warn',
     'eslint/sort-imports': 'warn',

--- a/tools/generate-react-queries/src/namespace-resolver.ts
+++ b/tools/generate-react-queries/src/namespace-resolver.ts
@@ -140,7 +140,7 @@ export async function buildNamespaceResolver(config: ReactQueriesConfig): Promis
  * like `RdbAdminv1.RdbV1ACLRule` instead of `Rdbv1.RdbV1ACLRule`.
  */
 function deriveFromNamespacePath(nsPath: string): ResolvedNamespace | undefined {
-  const match = nsPath.match(/^(@scaleway(?:-internal)?)\/sdk-([^/]+)\/(.+)$/)
+  const match = nsPath.match(/^(?<scope>@scaleway(?:-internal)?)\/sdk-(?<slug>[^/]+)\/(?<version>.+)$/)
   if (!match) return undefined
 
   const scope = match[1] // e.g. "@scaleway-internal" or "@scaleway"
@@ -150,7 +150,7 @@ function deriveFromNamespacePath(nsPath: string): ResolvedNamespace | undefined 
   if (!version) return undefined
 
   // Convert kebab-case slug to camelCase (e.g. "rdb-admin" → "rdbAdmin")
-  const camelSlug = slug.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
+  const camelSlug = slug.replace(/-(?<char>[a-z])/g, (_, c: string) => c.toUpperCase())
 
   return {
     packageName: `${scope}/sdk-${slug}`,

--- a/tools/generate-react-sdk/src/generateAPI/helpers.ts
+++ b/tools/generate-react-sdk/src/generateAPI/helpers.ts
@@ -1,5 +1,5 @@
 export function toCamelCase(input: string): string {
-  const camelCased = input.replace(/([-_][a-z])/gi, s => s.toUpperCase().replace(/[-_]/g, ''))
+  const camelCased = input.replace(/(?<prefix>[-_][a-z])/gi, s => s.toUpperCase().replace(/[-_]/g, ''))
 
   return camelCased.charAt(0).toLowerCase() + camelCased.slice(1)
 }

--- a/tools/pnpm-auto-release/src/utils.ts
+++ b/tools/pnpm-auto-release/src/utils.ts
@@ -125,7 +125,7 @@ export const createGithubReleases = ({
 
 const getRepoFromRemote = (root: string): string => {
   const remoteUrl = exec('git remote get-url origin', { cwd: root })
-  const match = remoteUrl.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/)
+  const match = remoteUrl.match(/github\.com[:/](?<repo>[^/]+\/[^/]+?)(?:\.git)?$/)
   if (!match?.[1]) {
     throw new Error('Could not determine GitHub repository from git remote')
   }


### PR DESCRIPTION
Fixes violations of `eslint/prefer-named-capture-group` and removes the rule from the warn list in `oxlint.config.ts`, enabling it as an error.

Closes #3389