### PR TITLE
fix(oxlint): enable eslint/prefer-destructuring as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -32,7 +32,6 @@ export default defineConfig({
     'eslint/no-implicit-coercion': 'warn',
     'eslint/no-use-before-define': 'warn',
     'eslint/no-useless-assignment': 'warn',
-    'eslint/prefer-destructuring': 'warn',
     'eslint/prefer-template': 'warn',
     'eslint/require-unicode-regexp': 'warn',
     'eslint/sort-imports': 'warn',

--- a/tools/generate-react-queries/src/namespace-resolver.ts
+++ b/tools/generate-react-queries/src/namespace-resolver.ts
@@ -143,10 +143,8 @@ function deriveFromNamespacePath(nsPath: string): ResolvedNamespace | undefined 
   const match = nsPath.match(/^(?<scope>@scaleway(?:-internal)?)\/sdk-(?<slug>[^/]+)\/(?<version>.+)$/)
   if (!match) return undefined
 
-  const scope = match[1] // e.g. "@scaleway-internal" or "@scaleway"
-  const slug = match[2] // e.g. "rdb", "rdb-admin", "baremetal"
+  const { scope, slug, version } = match?.groups ?? {} // e.g. "@scaleway-internal", "rdb-admin", "v1"
   if (!slug) return undefined
-  const version = match[3] // e.g. "v1", "v1alpha1"
   if (!version) return undefined
 
   // Convert kebab-case slug to camelCase (e.g. "rdb-admin" → "rdbAdmin")

--- a/tools/generate-react-sdk/src/parseArgsCLI.ts
+++ b/tools/generate-react-sdk/src/parseArgsCLI.ts
@@ -7,7 +7,7 @@ function parseSingleArg(arg: string, nextArg: string | undefined): ParsedArg | n
   if (!arg.startsWith('--')) return null
 
   const parts = arg.slice(2).split('=')
-  const key = parts[0]
+  const [key] = parts
   let value: string | boolean = parts.length > 1 ? (parts[1] as string) : true
   let consumedNext = false
 


### PR DESCRIPTION
Fixes violations of `eslint/prefer-destructuring` and removes the rule from the warn list in `oxlint.config.ts`, enabling it as an error.

Closes #3388