### PR TITLE
fix(oxlint): enable eslint/sort-imports as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -34,7 +34,6 @@ export default defineConfig({
     'eslint/no-useless-assignment': 'warn',
     'eslint/prefer-template': 'warn',
     'eslint/require-unicode-regexp': 'warn',
-    'eslint/sort-imports': 'warn',
     'import/no-nodejs-modules': 'warn',
     'node/no-process-env': 'warn',
     'oxc/no-accumulating-spread': 'warn',

--- a/tools/pnpm-auto-release/src/cli.ts
+++ b/tools/pnpm-auto-release/src/cli.ts
@@ -4,14 +4,14 @@ import { appendFileSync, realpathSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
-import { RELEASE_SUBJECT, CHANGESET_MESSAGE } from './constants.ts'
+import { CHANGESET_MESSAGE, RELEASE_SUBJECT } from './constants.ts'
 import {
+  createChangesets,
+  createGithubReleases,
   createTags,
   exec,
   findWorkspaceRoot,
   listWorkspacePackages,
-  createChangesets,
-  createGithubReleases,
 } from './utils.ts'
 
 const { log: logger } = console


### PR DESCRIPTION
Fix all `eslint/sort-imports` violations and enable the rule as error.

Closes #3392