### PR TITLE
feat(client): add cursor-based pagination support

### DIFF
--- a/packages/client/src/bridge.ts
+++ b/packages/client/src/bridge.ts
@@ -27,5 +27,5 @@ export {
 } from './scw/custom-marshalling.js'
 export type { Money, ScwFile, ServiceInfo, TimeSeries } from './scw/custom-types.js'
 export { Decimal } from './scw/custom-types.js'
-export { enrichForPagination } from './scw/fetch/resource-paginator.js'
+export { enrichForPagination, enrichForPaginationByCursor } from './scw/fetch/resource-paginator.js'
 export type { Region, Zone } from './scw/locality.js'

--- a/packages/client/src/internals.ts
+++ b/packages/client/src/internals.ts
@@ -28,4 +28,4 @@ export {
   unmarshalTimeSeriesPoint,
 } from './scw/custom-marshalling.js'
 export type { ServiceInfo } from './scw/custom-types.js'
-export { enrichForPagination } from './scw/fetch/resource-paginator.js'
+export { enrichForPagination, enrichForPaginationByCursor } from './scw/fetch/resource-paginator.js'

--- a/packages/client/src/scw/fetch/__tests__/resource-paginator.test.ts
+++ b/packages/client/src/scw/fetch/__tests__/resource-paginator.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { PaginatedContent, PaginatedFetcher } from '../resource-paginator.js'
-import { enrichForPagination, fetchAll, fetchPaginated } from '../resource-paginator.js'
+import type {
+  CursorPaginatedContent,
+  CursorPaginatedFetcher,
+  PaginatedContent,
+  PaginatedFetcher,
+} from '../resource-paginator.js'
+import {
+  enrichForPagination,
+  enrichForPaginationByCursor,
+  fetchAll,
+  fetchAllByCursor,
+  fetchPaginated,
+  fetchPaginatedByCursor,
+} from '../resource-paginator.js'
 
 const fetchPages = <T>(input: T[][] = [], delay = 0) => {
   const totalCount = input.flat().length
@@ -126,5 +138,85 @@ describe('enrichForPagination', () => {
       expect(page).toStrictEqual(input[readIndex - 1])
       readIndex += 1
     }
+  })
+})
+
+const fetchCursorPages = <T>(input: T[][] = []) => {
+  const pages = [...input]
+  return (request: { page?: string }) => {
+    const page = pages.shift()
+    const nextPageToken = pages.length ? 'token' : undefined
+    return Promise.resolve({ items: page ?? [], nextPageToken } as { items: T[]; nextPageToken?: string })
+  }
+}
+
+describe('fetchPaginatedByCursor', () => {
+  it('iterates page by page and stops when nextPageToken is absent', async () => {
+    const input = [[{ name: 'Alice' }, { name: 'Bob' }], [{ name: 'Julia' }, { name: 'Thomas' }], [{ name: 'David' }]]
+    const fetcher = vi.fn(fetchCursorPages(input))
+    const pages: unknown[] = []
+    for await (const page of fetchPaginatedByCursor('items', fetcher, {}, 'page')) {
+      pages.push(page)
+    }
+    expect(pages).toStrictEqual(input)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+    expect(fetcher).toHaveBeenLastCalledWith({ page: 'token' })
+  })
+
+  it('iterates a single page when no nextPageToken is returned', async () => {
+    const input = [[{ name: 'Alice' }, { name: 'Bob' }]]
+    const fetcher = vi.fn(fetchCursorPages(input))
+    const pages: unknown[] = []
+    for await (const page of fetchPaginatedByCursor('items', fetcher, {}, 'page')) {
+      pages.push(page)
+    }
+    expect(pages).toStrictEqual(input)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns empty array on empty result', async () => {
+    const fetcher = vi.fn(fetchCursorPages([]))
+    const iterator = fetchPaginatedByCursor('items', fetcher, {}, 'page')
+    const empty = await iterator.next()
+    expect(empty.value).toEqual([])
+    expect(empty.done).toBe(false)
+    const ended = await iterator.next()
+    expect(ended.value).toEqual(undefined)
+    expect(ended.done).toBe(true)
+  })
+
+  it('throws when wrong key is provided', async () => {
+    await expect(
+      fetchPaginatedByCursor(
+        'x',
+        fetchCursorPages([]) as unknown as CursorPaginatedFetcher<CursorPaginatedContent<'x'>>,
+        {},
+        'page',
+      ).next(),
+    ).rejects.toThrow(`Property x is not a list in paginated result`)
+  })
+})
+
+describe('fetchAllByCursor', () => {
+  it('fetches all items', async () => {
+    const input = [[{ name: 'Alice' }], [{ name: 'Bob' }], [{ name: 'Julia' }]]
+    expect(await fetchAllByCursor('items', fetchCursorPages(input), {}, 'page')).toStrictEqual(input.flat())
+  })
+})
+
+describe('enrichForPaginationByCursor', () => {
+  const input = [[{ name: 'Rémy' }, { name: 'Jaime' }], [{ name: 'Vincent' }]]
+
+  it('can fetch all items', () =>
+    expect(enrichForPaginationByCursor('items', fetchCursorPages(input), {}, 'page').all()).resolves.toStrictEqual(
+      input.flat(),
+    ))
+
+  it('can fetch items page by page', async () => {
+    const pages: unknown[] = []
+    for await (const page of enrichForPaginationByCursor('items', fetchCursorPages(input), {}, 'page')) {
+      pages.push(page)
+    }
+    expect(pages).toStrictEqual(input)
   })
 })

--- a/packages/client/src/scw/fetch/resource-paginator.ts
+++ b/packages/client/src/scw/fetch/resource-paginator.ts
@@ -98,3 +98,100 @@ export const enrichForPagination = <K extends string, T extends PaginatedContent
     [Symbol.asyncIterator]: () => fetchPaginated(key, fetcher, request, firstPage),
   })
 }
+
+export type CursorPaginatedFetcher<T, R = object> = (request: R) => Promise<T>
+
+export type CursorPaginatedContent<K extends string, T = unknown> = {
+  [key in K]: T[]
+} & {
+  nextPageToken?: string | null
+}
+
+async function* cursorPages<K extends string, T extends CursorPaginatedContent<K>, R>(
+  key: K,
+  fetcher: CursorPaginatedFetcher<T, R>,
+  request: R,
+  tokenKey: string,
+  firstPage: T,
+): AsyncGenerator<T[K], void, void> {
+  if (!Array.isArray(firstPage[key])) {
+    throw new Error(`Property ${key} is not a list in paginated result`)
+  }
+  let nextPageToken = firstPage.nextPageToken
+  yield firstPage[key]
+  while (nextPageToken) {
+    // eslint-disable-next-line no-await-in-loop
+    const page = await fetcher({ ...request, [tokenKey]: nextPageToken })
+    nextPageToken = page.nextPageToken
+    yield page[key]
+  }
+}
+
+/**
+ * Fetches a cursor-paginated resource.
+ *
+ * @param key - The resource key of values list
+ * @param fetcher - The method to retrieve paginated resources
+ * @param request - A request with pagination options
+ * @param tokenKey - The request field receiving the next page token
+ * @param initial - The first page
+ * @returns An async generator of resources arrays
+ */
+export async function* fetchPaginatedByCursor<K extends string, T extends CursorPaginatedContent<K>, R>(
+  key: K,
+  fetcher: CursorPaginatedFetcher<T, R>,
+  request: R,
+  tokenKey: string,
+  initial: Promise<T> = fetcher(request),
+) {
+  yield* cursorPages(key, fetcher, request, tokenKey, await initial)
+}
+
+/**
+ * Fetches all cursor-paginated resources.
+ *
+ * @param key - The resource key of values list
+ * @param fetcher - The method to retrieve paginated resources
+ * @param request - A request with pagination options
+ * @param tokenKey - The request field receiving the next page token
+ * @param initial - The first page
+ * @returns A resources array Promise
+ */
+export const fetchAllByCursor = async <K extends string, T extends CursorPaginatedContent<K>, R>(
+  key: K,
+  fetcher: CursorPaginatedFetcher<T, R>,
+  request: R,
+  tokenKey: string,
+  initial: Promise<T> = fetcher(request),
+) => {
+  const pages: T[K][] = []
+  for await (const page of fetchPaginatedByCursor(key, fetcher, request, tokenKey, initial)) {
+    pages.push(page)
+  }
+  return pages.flat()
+}
+
+/**
+ * Enriches a listing method with helpers.
+ *
+ * @param key - The resource key of values list
+ * @param fetcher - The method to retrieve paginated resources
+ * @param request - A request with pagination options
+ * @param tokenKey - The request field receiving the next page token
+ * @returns A resource Promise with the pagination helpers
+ *
+ * @internal
+ */
+export const enrichForPaginationByCursor = <K extends string, T extends CursorPaginatedContent<K>, R>(
+  key: K,
+  fetcher: CursorPaginatedFetcher<T, R>,
+  request: R,
+  tokenKey: string,
+) => {
+  const firstPage = fetcher(request)
+
+  return Object.assign(firstPage, {
+    all: () => fetchAllByCursor(key, fetcher, request, tokenKey, firstPage),
+    [Symbol.asyncIterator]: () => fetchPaginatedByCursor(key, fetcher, request, tokenKey, firstPage),
+  })
+}


### PR DESCRIPTION
Closes #3317

## Context

`resource-paginator.ts` only supports `page`/`pageSize` + `totalCount`-based pagination. Newer Scaleway APIs (IAM v2, search) use cursor-based pagination (`nextPageToken`), which couldn't use `enrichForPagination`.

## Changes

Adds cursor-based pagination alongside the existing page-based helpers, with the same `.all()` / `for await` ergonomics:

- `fetchPaginatedByCursor` — async generator keyed on `nextPageToken`
- `fetchAllByCursor` — flattens all pages
- `enrichForPaginationByCursor` — exposes `.all()` / `Symbol.asyncIterator`

Iteration stops when `nextPageToken` is absent/null. `tokenKey` parameterizes which request field carries the next-page token.

Exported from `bridge.ts` and `internals.ts`.

## Tests

Covers multi-page exhaustion, single-page, empty result, wrong-key error, and the `enrichForPaginationByCursor` helpers (100% coverage).

> Note: wiring generated APIs to pick the cursor variant via codegen metadata is left to the generator, which lives outside this repo.