### PR TITLE
fix(oxlint): enable eslint/max-params as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
     'eslint/eqeqeq': 'warn',
     'eslint/init-declarations': 'warn',
     'eslint/max-depth': 'warn',
-    'eslint/max-params': 'warn',
     'eslint/no-await-in-loop': 'warn',
     'eslint/no-bitwise': 'warn',
     'eslint/no-eq-null': 'warn',

--- a/packages/client/src/internal/async/__tests__/interval-retrier.test.ts
+++ b/packages/client/src/internal/async/__tests__/interval-retrier.test.ts
@@ -102,15 +102,17 @@ describe('tryAtIntervals', () => {
 
   it('does the proper number of iterations', async () => {
     const mLogic = mockLogic(3, 0)
-    const result = await tryAtIntervals(mLogic, zeroIntervalStrat, 0.5)
+    const result = await tryAtIntervals(mLogic, zeroIntervalStrat, { timeout: 0.5 })
     expect(result.doneIterations).toBe(3)
   })
 
   it('timeouts after 0s', () =>
-    expect(tryAtIntervals(mockLogic(3, 5), zeroIntervalStrat, 0)).rejects.toThrow(`Timeout after 0s`))
+    expect(tryAtIntervals(mockLogic(3, 5), zeroIntervalStrat, { timeout: 0 })).rejects.toThrow(`Timeout after 0s`))
 
   it('timeouts after 10ms', () =>
-    expect(tryAtIntervals(mockLogic(3, 5), zeroIntervalStrat, 0.01)).rejects.toThrow(`Timeout after 0.01s`))
+    expect(tryAtIntervals(mockLogic(3, 5), zeroIntervalStrat, { timeout: 0.01 })).rejects.toThrow(
+      `Timeout after 0.01s`,
+    ))
 
   it('uses default timeout', async () => {
     const mLogic = mockLogic(3, 0)
@@ -121,14 +123,14 @@ describe('tryAtIntervals', () => {
   it('throws an AbortError when the signal is already aborted', async () => {
     const controller = new AbortController()
     controller.abort()
-    await expect(tryAtIntervals(mockLogic(3, 0), zeroIntervalStrat, 1, controller.signal)).rejects.toThrow(
-      'The operation was aborted',
-    )
+    await expect(
+      tryAtIntervals(mockLogic(3, 0), zeroIntervalStrat, { timeout: 1, signal: controller.signal }),
+    ).rejects.toThrow('The operation was aborted')
   })
 
   it('throws an AbortError when the signal aborts mid-loop', async () => {
     const controller = new AbortController()
-    const result = tryAtIntervals(mockLogic(10, 0), zeroIntervalStrat, 5, controller.signal)
+    const result = tryAtIntervals(mockLogic(10, 0), zeroIntervalStrat, { timeout: 5, signal: controller.signal })
     controller.abort()
     await expect(result).rejects.toThrow('The operation was aborted')
   })
@@ -140,9 +142,10 @@ describe('waitForResource', () => {
       res => Promise.resolve(!['transient-one', 'transient-two'].includes(res.status)),
       () => Promise.resolve({ message: 'All went fine.', status: 'final' }),
       {
-        resourceId: 'random-uuid',
+        request: { resourceId: 'random-uuid' },
+        maxDelay: 1,
+        minDelay: 1,
       },
-      { maxDelay: 1, minDelay: 1 },
     )
 
     return expect(result).resolves.toStrictEqual({
@@ -160,9 +163,9 @@ describe('waitForResource', () => {
           status: 'transient-two',
         }),
       {
-        resourceId: 'random-uuid',
+        request: { resourceId: 'random-uuid' },
+        timeout: 0.01,
       },
-      { timeout: 0.01 },
     )
 
     return expect(result).rejects.toThrow()
@@ -174,8 +177,7 @@ describe('waitForResource', () => {
     const result = waitForResource(
       res => Promise.resolve(!['transient-one', 'transient-two'].includes(res.status)),
       () => Promise.resolve({ message: 'Still processing.', status: 'transient-two' }),
-      { resourceId: 'random-uuid' },
-      { maxDelay: 1, minDelay: 1, signal: controller.signal },
+      { request: { resourceId: 'random-uuid' }, maxDelay: 1, minDelay: 1, signal: controller.signal },
     )
 
     await expect(result).rejects.toThrow('The operation was aborted')

--- a/packages/client/src/internal/async/interval-retrier.ts
+++ b/packages/client/src/internal/async/interval-retrier.ts
@@ -87,8 +87,7 @@ export function* createExponentialBackoffStrategy(minDelay: number, maxDelay: nu
  *
  * @param retry - The function to retry logic between each interval
  * @param strategy - A generated interval strategy iterator
- * @param timeout - The maximum time elapsed before timeout error
- * @param signal - An {@link AbortSignal} to cancel the polling loop
+ * @param options - The timeout and abort signal options
  *
  * @throws An timeout exception, an {@link AbortError} or error thrown by the logic being run
  *
@@ -97,9 +96,9 @@ export function* createExponentialBackoffStrategy(minDelay: number, maxDelay: nu
 export const tryAtIntervals = async <T>(
   retry: Retry<T>,
   strategy: IntervalStrategy,
-  timeout: number = DEFAULT_TIMEOUT_SECONDS,
-  signal?: AbortSignal,
+  options: { timeout?: number; signal?: AbortSignal } = {},
 ): Promise<T> => {
+  const { timeout = DEFAULT_TIMEOUT_SECONDS, signal } = options
   const timeoutTimestamp = Date.now() + timeout * 1000
   let retryCount = 0
   while (Date.now() <= timeoutTimestamp) {
@@ -164,13 +163,27 @@ export interface WaitForOptions<T> {
 type ResourceFetcher<T, R> = (request: R) => Promise<T>
 
 /**
+ * The options to wait until a resource is ready.
+ *
+ * @public
+ */
+export interface WaitForResourceOptions<R, T> extends WaitForOptions<T> {
+  /**
+   * The resource request options.
+   */
+  request: R
+  /**
+   * An optional custom strategy.
+   */
+  strategy?: IntervalStrategy
+}
+
+/**
  * Fetches resource several times until an expected condition is reached, timeouts, or throws an exception.
  *
  * @param stop - The condition to stop waiting
  * @param fetcher - The method to retrieve resource
- * @param request - The resource request options
- * @param options - The retry strategy options
- * @param strategy - An optional custom strategy
+ * @param options - The request, retry strategy and wait options
  *
  * @returns A promise of resource
  *
@@ -179,16 +192,18 @@ type ResourceFetcher<T, R> = (request: R) => Promise<T>
 export const waitForResource = <R, T>(
   stop: WaitForStopCondition<T>,
   fetcher: ResourceFetcher<T, R>,
-  request: R,
-  options?: WaitForOptions<T>,
-  strategy: IntervalStrategy = createExponentialBackoffStrategy(
-    options?.minDelay ?? DEFAULT_MIN_DELAY_SECONDS,
-    options?.maxDelay ?? DEFAULT_MAX_DELAY_SECONDS,
-  ),
-) =>
-  tryAtIntervals(
+  options: Readonly<WaitForResourceOptions<R, T>>,
+) => {
+  const strategy =
+    options.strategy ??
+    createExponentialBackoffStrategy(
+      options.minDelay ?? DEFAULT_MIN_DELAY_SECONDS,
+      options.maxDelay ?? DEFAULT_MAX_DELAY_SECONDS,
+    )
+
+  return tryAtIntervals(
     async () => {
-      const value = await fetcher(request)
+      const value = await fetcher(options.request)
 
       return {
         done: await stop(value),
@@ -196,6 +211,6 @@ export const waitForResource = <R, T>(
       }
     },
     strategy,
-    options?.timeout,
-    options?.signal,
+    { timeout: options.timeout, signal: options.signal },
   )
+}

--- a/packages/client/src/scw/errors/non-standard/unknown-resource-mapper.ts
+++ b/packages/client/src/scw/errors/non-standard/unknown-resource-mapper.ts
@@ -17,15 +17,13 @@ export const mapUnknownResourceFromJSON = (
   // Examples: `"111..." not found` or `Security Group '111...' not found`
   const messageParts = typeof obj.message === 'string' ? obj.message.split(/"|'/) : []
   if (messageParts.length === 3 && isUUID(messageParts[1])) {
-    return new ResourceNotFoundError(
-      status,
-      obj,
+    return new ResourceNotFoundError(status, obj, {
       // transform `Security group ` to `security_group`
       // `.replaceAll()` may be too recent to use yet.
       // that's why we're using `.split(' ').join('_')` for now.
-      messageParts[0].trim().toLowerCase().split(' ').join('_'),
-      messageParts[1],
-    )
+      resource: messageParts[0].trim().toLowerCase().split(' ').join('_'),
+      resourceId: messageParts[1],
+    })
   }
 
   return new ScalewayError(status, obj)

--- a/packages/client/src/scw/errors/standard/already-exists-error.ts
+++ b/packages/client/src/scw/errors/standard/already-exists-error.ts
@@ -2,20 +2,40 @@ import type { JSONObject } from '../../../helpers/json.js'
 import { ScalewayError } from '../scw-error.js'
 
 /**
+ * Options for {@link AlreadyExistsError}.
+ *
+ * @public
+ */
+export interface AlreadyExistsErrorOptions {
+  resource: string
+  resourceId: string
+  helpMessage: string
+}
+
+/**
  * AlreadyExists error is used when a resource already exists.
  *
  * @public
  */
 export class AlreadyExistsError extends ScalewayError {
+  readonly resource: string
+  readonly resourceId: string
+  readonly helpMessage: string
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly resource: string,
-    readonly resourceId: string,
-    readonly helpMessage: string,
+    options: AlreadyExistsErrorOptions,
   ) {
-    super(status, body, `resource ${resource} with ID ${resourceId} already exists: ${helpMessage}`)
+    super(
+      status,
+      body,
+      `resource ${options.resource} with ID ${options.resourceId} already exists: ${options.helpMessage}`,
+    )
     this.name = 'AlreadyExistsError'
+    this.resource = options.resource
+    this.resourceId = options.resourceId
+    this.helpMessage = options.helpMessage
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>) {
@@ -27,6 +47,10 @@ export class AlreadyExistsError extends ScalewayError {
       return null
     }
 
-    return new AlreadyExistsError(status, obj, obj.resource, obj.resource_id, obj.help_message)
+    return new AlreadyExistsError(status, obj, {
+      resource: obj.resource,
+      resourceId: obj.resource_id,
+      helpMessage: obj.help_message,
+    })
   }
 }

--- a/packages/client/src/scw/errors/standard/denied-authentication-error.ts
+++ b/packages/client/src/scw/errors/standard/denied-authentication-error.ts
@@ -2,28 +2,37 @@ import type { JSONObject } from '../../../helpers/json.js'
 import { ScalewayError } from '../scw-error.js'
 
 /**
+ * Options for {@link DeniedAuthenticationError}.
+ *
+ * @public
+ */
+export interface DeniedAuthenticationErrorOptions {
+  method: string
+  reason: string
+}
+
+/**
  * Build the default message for {@link DeniedAuthenticationError}.
  *
- * @param method - The authentication method
- * @param reason - The deny reason
+ * @param options - The authentication method and deny reason
  * @returns The error message
  *
  * @internal
  */
-const buildMessage = (method: string, reason: string): string => {
+const buildMessage = (options: DeniedAuthenticationErrorOptions): string => {
   let reasonDesc: string
-  switch (reason) {
+  switch (options.reason) {
     case 'invalid_argument':
-      reasonDesc = `invalid ${method} format or empty value`
+      reasonDesc = `invalid ${options.method} format or empty value`
       break
     case 'not_found':
-      reasonDesc = `${method} does not exist`
+      reasonDesc = `${options.method} does not exist`
       break
     case 'expired':
-      reasonDesc = `${method} is expired`
+      reasonDesc = `${options.method} is expired`
       break
     default:
-      reasonDesc = `unknown reason for ${method}`
+      reasonDesc = `unknown reason for ${options.method}`
   }
 
   return `denied authentication: ${reasonDesc}`
@@ -35,14 +44,18 @@ const buildMessage = (method: string, reason: string): string => {
  * @public
  */
 export class DeniedAuthenticationError extends ScalewayError {
+  readonly method: string
+  readonly reason: string
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly method: string,
-    readonly reason: string,
+    options: DeniedAuthenticationErrorOptions,
   ) {
-    super(status, body, buildMessage(method, reason))
+    super(status, body, buildMessage(options))
     this.name = 'DeniedAuthenticationError'
+    this.method = options.method
+    this.reason = options.reason
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>) {
@@ -50,6 +63,6 @@ export class DeniedAuthenticationError extends ScalewayError {
       return null
     }
 
-    return new DeniedAuthenticationError(status, obj, obj.method, obj.reason)
+    return new DeniedAuthenticationError(status, obj, { method: obj.method, reason: obj.reason })
   }
 }

--- a/packages/client/src/scw/errors/standard/precondition-failed-error.ts
+++ b/packages/client/src/scw/errors/standard/precondition-failed-error.ts
@@ -2,18 +2,27 @@ import type { JSONObject } from '../../../helpers/json.js'
 import { ScalewayError } from '../scw-error.js'
 
 /**
+ * Options for {@link PreconditionFailedError}.
+ *
+ * @public
+ */
+export interface PreconditionFailedErrorOptions {
+  precondition: string
+  helpMessage: string
+}
+
+/**
  * Build the default message for {@link PreconditionFailedError}.
  *
- * @param precondition - The precondition
- * @param helpMessage - The message which should help the user to fix the root cause
+ * @param options - The precondition and help message
  * @returns The error message
  *
  * @internal
  */
-const buildMessage = (precondition: string, helpMessage: string): string => {
-  let message = `precondition failed: ${precondition}`
-  if (typeof helpMessage === 'string' && helpMessage.length > 0) {
-    message = message.concat(', ', helpMessage)
+const buildMessage = (options: PreconditionFailedErrorOptions): string => {
+  let message = `precondition failed: ${options.precondition}`
+  if (typeof options.helpMessage === 'string' && options.helpMessage.length > 0) {
+    message = message.concat(', ', options.helpMessage)
   }
 
   return message
@@ -25,14 +34,18 @@ const buildMessage = (precondition: string, helpMessage: string): string => {
  * @public
  */
 export class PreconditionFailedError extends ScalewayError {
+  readonly precondition: string
+  readonly helpMessage: string
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly precondition: string,
-    readonly helpMessage: string,
+    options: PreconditionFailedErrorOptions,
   ) {
-    super(status, body, buildMessage(precondition, helpMessage))
+    super(status, body, buildMessage(options))
     this.name = 'PreconditionFailedError'
+    this.precondition = options.precondition
+    this.helpMessage = options.helpMessage
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>) {
@@ -40,6 +53,9 @@ export class PreconditionFailedError extends ScalewayError {
       return null
     }
 
-    return new PreconditionFailedError(status, obj, obj.precondition, obj.help_message)
+    return new PreconditionFailedError(status, obj, {
+      precondition: obj.precondition,
+      helpMessage: obj.help_message,
+    })
   }
 }

--- a/packages/client/src/scw/errors/standard/resource-expired-error.ts
+++ b/packages/client/src/scw/errors/standard/resource-expired-error.ts
@@ -2,20 +2,40 @@ import type { JSONObject } from '../../../helpers/json.js'
 import { ScalewayError } from '../scw-error.js'
 
 /**
+ * Options for {@link ResourceExpiredError}.
+ *
+ * @public
+ */
+export interface ResourceExpiredErrorOptions {
+  resource: string
+  resourceId: string
+  expiredSince: Date
+}
+
+/**
  * ResourceExpired error happens when trying to access a resource that has expired.
  *
  * @public
  */
 export class ResourceExpiredError extends ScalewayError {
+  readonly resource: string
+  readonly resourceId: string
+  readonly expiredSince: Date
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly resource: string,
-    readonly resourceId: string,
-    readonly expiredSince: Date,
+    options: ResourceExpiredErrorOptions,
   ) {
-    super(status, body, `resource ${resource} with ID ${resourceId} expired since ${expiredSince.toISOString()}`)
+    super(
+      status,
+      body,
+      `resource ${options.resource} with ID ${options.resourceId} expired since ${options.expiredSince.toISOString()}`,
+    )
     this.name = 'ResourceExpiredError'
+    this.resource = options.resource
+    this.resourceId = options.resourceId
+    this.expiredSince = options.expiredSince
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>) {
@@ -27,6 +47,10 @@ export class ResourceExpiredError extends ScalewayError {
       return null
     }
 
-    return new ResourceExpiredError(status, obj, obj.resource, obj.resource_id, new Date(obj.expired_since))
+    return new ResourceExpiredError(status, obj, {
+      resource: obj.resource,
+      resourceId: obj.resource_id,
+      expiredSince: new Date(obj.expired_since),
+    })
   }
 }

--- a/packages/client/src/scw/errors/standard/resource-locked-error.ts
+++ b/packages/client/src/scw/errors/standard/resource-locked-error.ts
@@ -2,19 +2,33 @@ import type { JSONObject } from '../../../helpers/json.js'
 import { ScalewayError } from '../scw-error.js'
 
 /**
+ * Options for {@link ResourceLockedError}.
+ *
+ * @public
+ */
+export interface ResourceLockedErrorOptions {
+  resource: string
+  resourceId: string
+}
+
+/**
  * ResourceLocked error happens when a resource is locked by trust and safety.
  *
  * @public
  */
 export class ResourceLockedError extends ScalewayError {
+  readonly resource: string
+  readonly resourceId: string
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly resource: string,
-    readonly resourceId: string,
+    options: ResourceLockedErrorOptions,
   ) {
-    super(status, body, `resource ${resource} with ID ${resourceId} is locked`)
+    super(status, body, `resource ${options.resource} with ID ${options.resourceId} is locked`)
     this.name = 'ResourceLockedError'
+    this.resource = options.resource
+    this.resourceId = options.resourceId
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>) {
@@ -22,6 +36,6 @@ export class ResourceLockedError extends ScalewayError {
       return null
     }
 
-    return new ResourceLockedError(status, obj, obj.resource, obj.resource_id)
+    return new ResourceLockedError(status, obj, { resource: obj.resource, resourceId: obj.resource_id })
   }
 }

--- a/packages/client/src/scw/errors/standard/resource-not-found-error.ts
+++ b/packages/client/src/scw/errors/standard/resource-not-found-error.ts
@@ -2,19 +2,33 @@ import type { JSONObject } from '../../../helpers/json.js'
 import { ScalewayError } from '../scw-error.js'
 
 /**
+ * Options for {@link ResourceNotFoundError}.
+ *
+ * @public
+ */
+export interface ResourceNotFoundErrorOptions {
+  resource: string
+  resourceId: string
+}
+
+/**
  * ResourceNotFound error happens when getting a resource that does not exist anymore.
  *
  * @public
  */
 export class ResourceNotFoundError extends ScalewayError {
+  readonly resource: string
+  readonly resourceId: string
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly resource: string,
-    readonly resourceId: string,
+    options: ResourceNotFoundErrorOptions,
   ) {
-    super(status, body, `resource ${resource} with ID ${resourceId} is not found`)
+    super(status, body, `resource ${options.resource} with ID ${options.resourceId} is not found`)
     this.name = 'ResourceNotFoundError'
+    this.resource = options.resource
+    this.resourceId = options.resourceId
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>) {
@@ -22,6 +36,6 @@ export class ResourceNotFoundError extends ScalewayError {
       return null
     }
 
-    return new ResourceNotFoundError(status, obj, obj.resource, obj.resource_id)
+    return new ResourceNotFoundError(status, obj, { resource: obj.resource, resourceId: obj.resource_id })
   }
 }

--- a/packages/client/src/scw/errors/standard/too-many-requests-error.ts
+++ b/packages/client/src/scw/errors/standard/too-many-requests-error.ts
@@ -13,16 +13,26 @@ export interface TooManyRequestsQuotaPolicy {
 }
 
 /**
+ * Options for {@link TooManyRequestsError}.
+ *
+ * @public
+ */
+export interface TooManyRequestsErrorOptions {
+  helpMessage: string
+  limit?: TooManyRequestsQuotaPolicy
+  /** The number of seconds until the quota resets */
+  resetSeconds?: number
+  /** The timestamp when the quota resets */
+  resetAt?: Date
+}
+
+/**
  * Build the default message for {@link TooManyRequestsError}.
  *
  * @internal
  */
-const buildMessage = (
-  helpMessage: string,
-  limit?: TooManyRequestsQuotaPolicy,
-  resetSeconds?: number,
-  resetAt?: Date,
-): string => {
+const buildMessage = (options: TooManyRequestsErrorOptions): string => {
+  const { helpMessage, limit, resetSeconds, resetAt } = options
   const details: string[] = []
   if (limit) {
     if (limit.windowSeconds) {
@@ -54,18 +64,24 @@ const buildMessage = (
  * @public
  */
 export class TooManyRequestsError extends ScalewayError {
+  readonly helpMessage: string
+  readonly limit?: TooManyRequestsQuotaPolicy
+  /** The number of seconds until the quota resets */
+  readonly resetSeconds?: number
+  /** The timestamp when the quota resets */
+  readonly resetAt?: Date
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly helpMessage: string,
-    readonly limit?: TooManyRequestsQuotaPolicy,
-    /** The number of seconds until the quota resets */
-    readonly resetSeconds?: number,
-    /** The timestamp when the quota resets */
-    readonly resetAt?: Date,
+    options: TooManyRequestsErrorOptions,
   ) {
-    super(status, body, buildMessage(helpMessage, limit, resetSeconds, resetAt))
+    super(status, body, buildMessage(options))
     this.name = 'TooManyRequestsError'
+    this.helpMessage = options.helpMessage
+    this.limit = options.limit
+    this.resetSeconds = options.resetSeconds
+    this.resetAt = options.resetAt
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>) {
@@ -78,13 +94,11 @@ export class TooManyRequestsError extends ScalewayError {
       }
     }
 
-    return new TooManyRequestsError(
-      status,
-      obj,
-      obj.help_message,
+    return new TooManyRequestsError(status, obj, {
+      helpMessage: obj.help_message,
       limit,
-      typeof obj.reset_seconds === 'number' ? obj.reset_seconds : undefined,
-      typeof obj.reset_at === 'string' ? new Date(obj.reset_at) : undefined,
-    )
+      resetSeconds: typeof obj.reset_seconds === 'number' ? obj.reset_seconds : undefined,
+      resetAt: typeof obj.reset_at === 'string' ? new Date(obj.reset_at) : undefined,
+    })
   }
 }

--- a/packages/client/src/scw/errors/standard/transient-state-error.ts
+++ b/packages/client/src/scw/errors/standard/transient-state-error.ts
@@ -2,20 +2,40 @@ import type { JSONObject } from '../../../helpers/json.js'
 import { ScalewayError } from '../scw-error.js'
 
 /**
+ * Options for {@link TransientStateError}.
+ *
+ * @public
+ */
+export interface TransientStateErrorOptions {
+  resource: string
+  resourceId: string
+  currentState: string
+}
+
+/**
  * TransientState error happens when trying to perform an action on a resource in a transient state.
  *
  * @public
  */
 export class TransientStateError extends ScalewayError {
+  readonly resource: string
+  readonly resourceId: string
+  readonly currentState: string
+
   constructor(
     readonly status: number,
     readonly body: JSONObject,
-    readonly resource: string,
-    readonly resourceId: string,
-    readonly currentState: string,
+    options: TransientStateErrorOptions,
   ) {
-    super(status, body, `resource ${resource} with ID ${resourceId} is in a transient state: ${currentState}`)
+    super(
+      status,
+      body,
+      `resource ${options.resource} with ID ${options.resourceId} is in a transient state: ${options.currentState}`,
+    )
     this.name = 'TransientStateError'
+    this.resource = options.resource
+    this.resourceId = options.resourceId
+    this.currentState = options.currentState
   }
 
   static fromJSON(status: number, obj: Readonly<JSONObject>): ScalewayError | null {
@@ -27,6 +47,10 @@ export class TransientStateError extends ScalewayError {
       return null
     }
 
-    return new TransientStateError(status, obj, obj.resource, obj.resource_id, obj.current_state)
+    return new TransientStateError(status, obj, {
+      resource: obj.resource,
+      resourceId: obj.resource_id,
+      currentState: obj.current_state,
+    })
   }
 }

--- a/packages/client/src/scw/fetch/__tests__/resource-paginator.test.ts
+++ b/packages/client/src/scw/fetch/__tests__/resource-paginator.test.ts
@@ -21,7 +21,7 @@ const fetchPages = <T>(input: T[][] = [], delay = 0) => {
 describe('fetchPaginated', () => {
   it('iterate page by page', async () => {
     const input = [[{ name: 'Alice' }, { name: 'Bob' }], [{ name: 'Julia' }, { name: 'Thomas' }], [{ name: 'David' }]]
-    for await (const page of fetchPaginated('items', fetchPages(input), {})) {
+    for await (const page of fetchPaginated('items', fetchPages(input), { request: {} })) {
       expect(page).toStrictEqual(input.shift())
     }
   })
@@ -30,7 +30,7 @@ describe('fetchPaginated', () => {
     const input = [[{ name: 'Alice' }, { name: 'Bob' }], [{ name: 'Julia' }, { name: 'Thomas' }], [{ name: 'David' }]]
     let readIndex = 2
     for await (const page of fetchPaginated('items', fetchPages(input), {
-      page: readIndex,
+      request: { page: readIndex },
     })) {
       expect(page).toStrictEqual(input[readIndex - 1])
       readIndex += 1
@@ -40,7 +40,7 @@ describe('fetchPaginated', () => {
   it('iterate without over iteration - 2 pages', async () => {
     const twoPages = [[{ name: 'Alice' }, { name: 'Bob' }], [{ name: 'Claire' }]]
     const twoPagesFetcher = vi.fn(fetchPages(twoPages))
-    for await (const page of fetchPaginated('items', twoPagesFetcher, {})) {
+    for await (const page of fetchPaginated('items', twoPagesFetcher, { request: {} })) {
       expect(page).toStrictEqual(twoPages.shift())
     }
     expect(twoPagesFetcher).toHaveBeenCalledTimes(2)
@@ -49,7 +49,7 @@ describe('fetchPaginated', () => {
   it('iterate without over iteration - 1 page', async () => {
     const onePage = [[{ name: 'Alice' }, { name: 'Bob' }], []]
     const onePagesFetcher = vi.fn(fetchPages(onePage))
-    for await (const page of fetchPaginated('items', onePagesFetcher, {})) {
+    for await (const page of fetchPaginated('items', onePagesFetcher, { request: {} })) {
       expect(page).toStrictEqual(onePage.shift())
     }
     expect(onePage).toStrictEqual([[]])
@@ -59,14 +59,14 @@ describe('fetchPaginated', () => {
   it('iterate without over iteration - 1 result', async () => {
     const singleResult = [[{ name: 'Alice' }]]
     const singleResultFetcher = vi.fn(fetchPages(singleResult))
-    for await (const page of fetchPaginated('items', singleResultFetcher, {})) {
+    for await (const page of fetchPaginated('items', singleResultFetcher, { request: {} })) {
       expect(page).toStrictEqual(singleResult.shift())
     }
     expect(singleResultFetcher).toHaveBeenCalledTimes(1)
   })
 
   it('returns empty array on empty result', async () => {
-    const iterator = fetchPaginated('items', fetchPages([]), {})
+    const iterator = fetchPaginated('items', fetchPages([]), { request: {} })
     const empty = await iterator.next()
     expect(empty.value).toEqual([])
     expect(empty.done).toBe(false)
@@ -77,7 +77,7 @@ describe('fetchPaginated', () => {
 
   it('throws when wrong key is provided', async () => {
     await expect(
-      fetchPaginated('x', fetchPages([]) as unknown as PaginatedFetcher<PaginatedContent<'x'>>, {}).next(),
+      fetchPaginated('x', fetchPages([]) as unknown as PaginatedFetcher<PaginatedContent<'x'>>, { request: {} }).next(),
     ).rejects.toThrow(`Property x is not a list in paginated result`)
   })
 })
@@ -107,7 +107,7 @@ describe('fetchAll', () => {
     const delay = 50
     const tolerance = 50
     const startTime = Date.now()
-    expect(await fetchAll('items', fetchPages(input, 50), {})).toStrictEqual(input.flat())
+    expect(await fetchAll('items', fetchPages(input, 50), { request: {} })).toStrictEqual(input.flat())
     expect(Date.now() - startTime).toBeLessThanOrEqual(2 * delay + tolerance)
   })
 })

--- a/packages/client/src/scw/fetch/resource-paginator.ts
+++ b/packages/client/src/scw/fetch/resource-paginator.ts
@@ -18,12 +18,17 @@ export const extract =
   <T extends PaginatedContent<K>>(result: T) =>
     result[key]
 
+interface PaginationCallOptions<K extends string, T extends PaginatedContent<K>, R extends PaginationOptions> {
+  request: R
+  initial?: Promise<T>
+}
+
 function* pages<K extends string, T extends PaginatedContent<K>, R extends PaginationOptions>(
   key: K,
   fetcher: PaginatedFetcher<T, R>,
-  request: R,
-  firstPage: T,
+  options: { request: R; firstPage: T },
 ): Generator<Promise<T[K]>, void, void> {
+  const { request, firstPage } = options
   if (!Array.isArray(firstPage[key])) {
     throw new Error(`Property ${key} is not a list in paginated result`)
   }
@@ -47,17 +52,16 @@ function* pages<K extends string, T extends PaginatedContent<K>, R extends Pagin
  *
  * @param key - The resource key of values list
  * @param fetcher - The method to retrieve paginated resources
- * @param request - A request with pagination options
- * @param initial - The first page
+ * @param options - A request with pagination options and an optional first page
  * @returns An async generator of resources arrays
  */
 export async function* fetchPaginated<K extends string, T extends PaginatedContent<K>, R extends PaginationOptions>(
   key: K,
   fetcher: PaginatedFetcher<T, R>,
-  request: R,
-  initial: Promise<T> = fetcher(request),
+  options: PaginationCallOptions<K, T, R>,
 ) {
-  yield* pages(key, fetcher, request, await initial)
+  const firstPage = await (options.initial ?? fetcher(options.request))
+  yield* pages(key, fetcher, { request: options.request, firstPage })
 }
 
 /**
@@ -65,16 +69,17 @@ export async function* fetchPaginated<K extends string, T extends PaginatedConte
  *
  * @param key - The resource key of values list
  * @param fetcher - The method to retrieve paginated resources
- * @param request - A request with pagination options
- * @param initial - The first page
+ * @param options - A request with pagination options and an optional first page
  * @returns A resources array Promise
  */
 export const fetchAll = async <K extends string, T extends PaginatedContent<K>, R extends PaginationOptions>(
   key: K,
   fetcher: PaginatedFetcher<T, R>,
-  request: R,
-  initial: Promise<T> = fetcher(request),
-) => (await Promise.all(Array.from(pages(key, fetcher, request, await initial)))).flat()
+  options: PaginationCallOptions<K, T, R>,
+) => {
+  const firstPage = await (options.initial ?? fetcher(options.request))
+  return (await Promise.all(Array.from(pages(key, fetcher, { request: options.request, firstPage })))).flat()
+}
 
 /**
  * Enriches a listing method with helpers.
@@ -94,7 +99,7 @@ export const enrichForPagination = <K extends string, T extends PaginatedContent
   const firstPage = fetcher(request)
 
   return Object.assign(firstPage, {
-    all: () => fetchAll(key, fetcher, request, firstPage),
-    [Symbol.asyncIterator]: () => fetchPaginated(key, fetcher, request, firstPage),
+    all: () => fetchAll(key, fetcher, { request, initial: firstPage }),
+    [Symbol.asyncIterator]: () => fetchPaginated(key, fetcher, { request, initial: firstPage }),
   })
 }

--- a/packages_generated/account/src/v3/api.gen.ts
+++ b/packages_generated/account/src/v3/api.gen.ts
@@ -243,8 +243,7 @@ export class ProjectAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!PROJECT_TRANSIENT_STATUSES_ACCOUNT.includes(res.status))),
       this.getProject,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/applesilicon/src/v1alpha1/api.gen.ts
+++ b/packages_generated/applesilicon/src/v1alpha1/api.gen.ts
@@ -274,8 +274,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SERVER_TRANSIENT_STATUSES_APPLESILICON.includes(res.status))),
       this.getServer,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -424,8 +423,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!RUNNER_TRANSIENT_STATUSES_APPLESILICON.includes(res.status))),
       this.getRunner,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -554,8 +552,7 @@ export class PrivateNetworkAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SERVER_PRIVATE_NETWORK_SERVER_TRANSIENT_STATUSES_APPLESILICON.includes(res.status))),
       this.getServerPrivateNetwork,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/autoscaling/src/v1alpha2/api.gen.ts
+++ b/packages_generated/autoscaling/src/v1alpha2/api.gen.ts
@@ -112,8 +112,7 @@ configuration, current size, and status.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!GROUP_GROUP_TRANSIENT_STATUSES_AUTOSCALING.includes(res.status))),
       this.getGroup,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/baremetal/src/v1/api.gen.ts
+++ b/packages_generated/baremetal/src/v1/api.gen.ts
@@ -186,8 +186,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SERVER_TRANSIENT_STATUSES_BAREMETAL.includes(res.status))),
       this.getServer,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/block/src/v1/api.gen.ts
+++ b/packages_generated/block/src/v1/api.gen.ts
@@ -182,8 +182,7 @@ To create a volume from an existing snapshot, specify `from_snapshot` and the `s
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!VOLUME_TRANSIENT_STATUSES_BLOCK.includes(res.status))),
       this.getVolume,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -281,8 +280,7 @@ You can only resize a volume to a larger size. It is currently not possible to c
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SNAPSHOT_TRANSIENT_STATUSES_BLOCK.includes(res.status))),
       this.getSnapshot,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/block/src/v1alpha1/api.gen.ts
+++ b/packages_generated/block/src/v1alpha1/api.gen.ts
@@ -179,8 +179,7 @@ To create a volume from an existing snapshot, specify `from_snapshot` and the `s
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!VOLUME_TRANSIENT_STATUSES_BLOCK.includes(res.status))),
       this.getVolume,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -277,8 +276,7 @@ You can only resize a volume to a larger size. It is currently not possible to c
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SNAPSHOT_TRANSIENT_STATUSES_BLOCK.includes(res.status))),
       this.getSnapshot,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/cockpit/src/v1/api.gen.ts
+++ b/packages_generated/cockpit/src/v1/api.gen.ts
@@ -492,8 +492,7 @@ Optionally, specify a Scaleway data source ID to retrieve only data exports asso
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!EXPORTER_TRANSIENT_STATUSES_COCKPIT.includes(res.status))),
       this.getExporter,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/container/src/v1/api.gen.ts
+++ b/packages_generated/container/src/v1/api.gen.ts
@@ -135,8 +135,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!NAMESPACE_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getNamespace,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -256,8 +255,7 @@ This action **cannot** be undone.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CONTAINER_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getContainer,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -378,8 +376,7 @@ This action **cannot** be undone.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DOMAIN_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getDomain,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -518,8 +515,7 @@ the most recent image version available in the registry.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!TRIGGER_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getTrigger,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/container/src/v1beta1/api.gen.ts
+++ b/packages_generated/container/src/v1beta1/api.gen.ts
@@ -165,8 +165,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!NAMESPACE_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getNamespace,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -288,8 +287,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CONTAINER_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getContainer,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -438,8 +436,7 @@ Moreover, calling `DeployContainer` immediately after `UpdateContainer` can caus
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CRON_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getCron,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -558,8 +555,7 @@ Moreover, calling `DeployContainer` immediately after `UpdateContainer` can caus
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DOMAIN_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getDomain,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -652,8 +648,7 @@ Moreover, calling `DeployContainer` immediately after `UpdateContainer` can caus
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!TOKEN_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getToken,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -752,8 +747,7 @@ Moreover, calling `DeployContainer` immediately after `UpdateContainer` can caus
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!TRIGGER_TRANSIENT_STATUSES_CONTAINER.includes(res.status))),
       this.getTrigger,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/datalab/src/v1beta1/api.gen.ts
+++ b/packages_generated/datalab/src/v1beta1/api.gen.ts
@@ -108,8 +108,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DATALAB_TRANSIENT_STATUSES_DATALAB.includes(res.status))),
       this.getDatalab,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/dataviz/src/v1alpha1/api.gen.ts
+++ b/packages_generated/dataviz/src/v1alpha1/api.gen.ts
@@ -162,8 +162,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DEPLOYMENT_TRANSIENT_STATUSES_DATAVIZ.includes(res.status))),
       this.getDeployment,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/datawarehouse/src/v1beta1/api.gen.ts
+++ b/packages_generated/datawarehouse/src/v1beta1/api.gen.ts
@@ -185,8 +185,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DEPLOYMENT_TRANSIENT_STATUSES_DATAWAREHOUSE.includes(res.status))),
       this.getDeployment,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/dedibox/src/v1/api.gen.ts
+++ b/packages_generated/dedibox/src/v1/api.gen.ts
@@ -321,8 +321,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SERVER_TRANSIENT_STATUSES_DEDIBOX.includes(res.status))),
       this.getServer,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -695,8 +694,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SERVER_INSTALL_TRANSIENT_STATUSES_DEDIBOX.includes(res.status))),
       this.getServerInstall,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -778,8 +776,7 @@ The BMC (Baseboard Management Controller) access is available one hour after the
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!BMC_ACCESS_TRANSIENT_STATUSES_DEDIBOX.includes(res.status))),
       this.getBMCAccess,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1527,8 +1524,7 @@ export class RpnSanAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!RPN_SAN_TRANSIENT_STATUSES_DEDIBOX.includes(res.status))),
       this.getRpnSan,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1894,8 +1890,7 @@ export class RpnV2API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!RPN_V2_GROUP_TRANSIENT_STATUSES_DEDIBOX.includes(res.status))),
       this.getRpnV2Group,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/domain/src/v2beta1/api.gen.ts
+++ b/packages_generated/domain/src/v2beta1/api.gen.ts
@@ -595,8 +595,7 @@ The maximum version count is 100. If the count reaches this limit, the oldest ve
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SSL_CERTIFICATE_TRANSIENT_STATUSES_DOMAIN.includes(res.status))),
       this.getSSLCertificate,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1067,8 +1066,7 @@ You can filter the list by domain name.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DOMAIN_TRANSIENT_STATUSES_DOMAIN.includes(res.status))),
       this.getDomain,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/edge_services/src/v1beta1/api.gen.ts
+++ b/packages_generated/edge_services/src/v1beta1/api.gen.ts
@@ -261,8 +261,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!PIPELINE_TRANSIENT_STATUSES_EDGE_SERVICES.includes(res.status))),
       this.getPipeline,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1248,8 +1247,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!PURGE_REQUEST_TRANSIENT_STATUSES_EDGE_SERVICES.includes(res.status))),
       this.getPurgeRequest,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/file/src/v1alpha1/api.gen.ts
+++ b/packages_generated/file/src/v1alpha1/api.gen.ts
@@ -107,8 +107,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!FILE_SYSTEM_TRANSIENT_STATUSES_FILE.includes(res.status))),
       this.getFileSystem,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/flexibleip/src/v1alpha1/api.gen.ts
+++ b/packages_generated/flexibleip/src/v1alpha1/api.gen.ts
@@ -118,8 +118,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!FLEXIBLE_IP_TRANSIENT_STATUSES_FLEXIBLEIP.includes(res.status))),
       this.getFlexibleIP,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/function/src/v1beta1/api.gen.ts
+++ b/packages_generated/function/src/v1beta1/api.gen.ts
@@ -168,8 +168,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!NAMESPACE_TRANSIENT_STATUSES_FUNCTION.includes(res.status))),
       this.getNamespace,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -286,8 +285,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!FUNCTION_TRANSIENT_STATUSES_FUNCTION.includes(res.status))),
       this.getFunction,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -473,8 +471,7 @@ This behavior can be changed by setting the `redeploy` field to `false` in the r
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CRON_TRANSIENT_STATUSES_FUNCTION.includes(res.status))),
       this.getCron,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -588,8 +585,7 @@ This behavior can be changed by setting the `redeploy` field to `false` in the r
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DOMAIN_TRANSIENT_STATUSES_FUNCTION.includes(res.status))),
       this.getDomain,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -679,8 +675,7 @@ This behavior can be changed by setting the `redeploy` field to `false` in the r
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!TOKEN_TRANSIENT_STATUSES_FUNCTION.includes(res.status))),
       this.getToken,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -775,8 +770,7 @@ This behavior can be changed by setting the `redeploy` field to `false` in the r
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!TRIGGER_TRANSIENT_STATUSES_FUNCTION.includes(res.status))),
       this.getTrigger,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/inference/src/v1/api.gen.ts
+++ b/packages_generated/inference/src/v1/api.gen.ts
@@ -126,8 +126,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DEPLOYMENT_TRANSIENT_STATUSES_INFERENCE.includes(res.status))),
       this.getDeployment,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -318,8 +317,7 @@ The CA certificate will be returned as a PEM file.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!MODEL_TRANSIENT_STATUSES_INFERENCE.includes(res.status))),
       this.getModel,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/inference/src/v1beta1/api.gen.ts
+++ b/packages_generated/inference/src/v1beta1/api.gen.ts
@@ -136,8 +136,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DEPLOYMENT_TRANSIENT_STATUSES_INFERENCE.includes(res.status))),
       this.getDeployment,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/instance/src/v1/api.utils.ts
+++ b/packages_generated/instance/src/v1/api.utils.ts
@@ -59,7 +59,7 @@ export class InstanceV1UtilsAPI extends API {
         }
       },
       createExponentialBackoffStrategy(options?.minDelay ?? 1, options?.maxDelay ?? 30),
-      options?.timeout,
+      { timeout: options?.timeout },
     )
 
   /**
@@ -80,7 +80,7 @@ export class InstanceV1UtilsAPI extends API {
         }
       },
       createExponentialBackoffStrategy(options?.minDelay ?? 1, options?.maxDelay ?? 30),
-      options?.timeout,
+      { timeout: options?.timeout },
     )
 
   /**
@@ -101,7 +101,7 @@ export class InstanceV1UtilsAPI extends API {
         }
       },
       createExponentialBackoffStrategy(options?.minDelay ?? 1, options?.maxDelay ?? 30),
-      options?.timeout,
+      { timeout: options?.timeout },
     )
 
   /**
@@ -122,7 +122,7 @@ export class InstanceV1UtilsAPI extends API {
         }
       },
       createExponentialBackoffStrategy(options?.minDelay ?? 1, options?.maxDelay ?? 30),
-      options?.timeout,
+      { timeout: options?.timeout },
     )
 
   /**
@@ -143,7 +143,7 @@ export class InstanceV1UtilsAPI extends API {
         }
       },
       createExponentialBackoffStrategy(options?.minDelay ?? 1, options?.maxDelay ?? 30),
-      options?.timeout,
+      { timeout: options?.timeout },
     )
 
   /**

--- a/packages_generated/instance/src/v2alpha1/api.gen.ts
+++ b/packages_generated/instance/src/v2alpha1/api.gen.ts
@@ -302,8 +302,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SERVER_TRANSIENT_STATUSES_INSTANCE.includes(res.status))),
       this.getServer,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -733,8 +732,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!PRIVATE_NETWORK_INTERFACE_TRANSIENT_STATUSES_INSTANCE.includes(res.status))),
       this.getPrivateNetworkInterface,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1513,8 +1511,7 @@ export class VolumeAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!VOLUME_TRANSIENT_STATUSES_INSTANCE.includes(res.status))),
       this.getVolume,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1627,8 +1624,7 @@ export class VolumeAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SNAPSHOT_TRANSIENT_STATUSES_INSTANCE.includes(res.status))),
       this.getSnapshot,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/interlink/src/v1beta1/api.gen.ts
+++ b/packages_generated/interlink/src/v1beta1/api.gen.ts
@@ -152,8 +152,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DEDICATED_CONNECTION_TRANSIENT_STATUSES_INTERLINK.includes(res.status))),
       this.getDedicatedConnection,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -313,8 +312,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!LINK_TRANSIENT_STATUSES_INTERLINK.includes(res.status))),
       this.getLink,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/iot/src/v1/api.gen.ts
+++ b/packages_generated/iot/src/v1/api.gen.ts
@@ -197,8 +197,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!HUB_TRANSIENT_STATUSES_IOT.includes(res.status))),
       this.getHub,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/k8s/src/v1/api.gen.ts
+++ b/packages_generated/k8s/src/v1/api.gen.ts
@@ -203,8 +203,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CLUSTER_TRANSIENT_STATUSES_K8S.includes(res.status))),
       this.getCluster,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -501,8 +500,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!POOL_TRANSIENT_STATUSES_K8S.includes(res.status))),
       this.getPool,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -749,8 +747,7 @@ Tip: add `?dl=1` at the end of the URL to directly retrieve the base64 decoded c
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!NODE_TRANSIENT_STATUSES_K8S.includes(res.status))),
       this.getNode,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/kafka/src/v1alpha1/api.gen.ts
+++ b/packages_generated/kafka/src/v1alpha1/api.gen.ts
@@ -174,8 +174,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CLUSTER_TRANSIENT_STATUSES_KAFKA.includes(res.status))),
       this.getCluster,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/lb/src/v1/api.gen.ts
+++ b/packages_generated/lb/src/v1/api.gen.ts
@@ -324,8 +324,7 @@ export class ZonedAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!LB_TRANSIENT_STATUSES_LB.includes(res.status))),
       this.getLb,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1082,8 +1081,7 @@ export class ZonedAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CERTIFICATE_TRANSIENT_STATUSES_LB.includes(res.status))),
       this.getCertificate,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1438,8 +1436,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!LB_TRANSIENT_STATUSES_LB.includes(res.status))),
       this.getLb,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -2176,8 +2173,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CERTIFICATE_TRANSIENT_STATUSES_LB.includes(res.status))),
       this.getCertificate,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/mailbox/src/v1alpha1/api.gen.ts
+++ b/packages_generated/mailbox/src/v1alpha1/api.gen.ts
@@ -141,8 +141,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DOMAIN_TRANSIENT_STATUSES_MAILBOX.includes(res.status))),
       this.getDomain,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -271,8 +270,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!MAILBOX_TRANSIENT_STATUSES_MAILBOX.includes(res.status))),
       this.getMailbox,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -406,8 +404,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!ALIAS_TRANSIENT_STATUSES_MAILBOX.includes(res.status))),
       this.getAlias,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/messageq/src/v1alpha1/api.gen.ts
+++ b/packages_generated/messageq/src/v1alpha1/api.gen.ts
@@ -162,8 +162,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DEPLOYMENT_TRANSIENT_STATUSES_MESSAGEQ.includes(res.status))),
       this.getDeployment,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/mongodb/src/v1/api.gen.ts
+++ b/packages_generated/mongodb/src/v1/api.gen.ts
@@ -204,8 +204,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!INSTANCE_TRANSIENT_STATUSES_MONGODB.includes(res.status))),
       this.getInstance,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -353,8 +352,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SNAPSHOT_TRANSIENT_STATUSES_MONGODB.includes(res.status))),
       this.getSnapshot,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -653,8 +651,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!MAINTENANCE_TRANSIENT_STATUSES_MONGODB.includes(res.status))),
       this.getMaintenance,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/mongodb/src/v1alpha1/api.gen.ts
+++ b/packages_generated/mongodb/src/v1alpha1/api.gen.ts
@@ -193,8 +193,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!INSTANCE_TRANSIENT_STATUSES_MONGODB.includes(res.status))),
       this.getInstance,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -342,8 +341,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SNAPSHOT_TRANSIENT_STATUSES_MONGODB.includes(res.status))),
       this.getSnapshot,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/qaas/src/v1alpha1/api.gen.ts
+++ b/packages_generated/qaas/src/v1alpha1/api.gen.ts
@@ -132,8 +132,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!JOB_TRANSIENT_STATUSES_QAAS.includes(res.status))),
       this.getJob,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -356,8 +355,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SESSION_TRANSIENT_STATUSES_QAAS.includes(res.status))),
       this.getSession,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -527,8 +525,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!PROCESS_TRANSIENT_STATUSES_QAAS.includes(res.status))),
       this.getProcess,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -706,8 +703,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!BOOKING_TRANSIENT_STATUSES_QAAS.includes(res.status))),
       this.getBooking,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/rdb/src/v1/api.gen.ts
+++ b/packages_generated/rdb/src/v1/api.gen.ts
@@ -308,8 +308,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DATABASE_BACKUP_TRANSIENT_STATUSES_RDB.includes(res.status))),
       this.getDatabaseBackup,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -465,8 +464,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!INSTANCE_TRANSIENT_STATUSES_RDB.includes(res.status))),
       this.getInstance,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -670,8 +668,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!READ_REPLICA_TRANSIENT_STATUSES_RDB.includes(res.status))),
       this.getReadReplica,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -816,8 +813,7 @@ The configured endpoints do not change.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!INSTANCE_LOG_TRANSIENT_STATUSES_RDB.includes(res.status))),
       this.getInstanceLog,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -1242,8 +1238,7 @@ The configured endpoints do not change.
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!SNAPSHOT_TRANSIENT_STATUSES_RDB.includes(res.status))),
       this.getSnapshot,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/redis/src/v1/api.gen.ts
+++ b/packages_generated/redis/src/v1/api.gen.ts
@@ -169,8 +169,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!CLUSTER_TRANSIENT_STATUSES_REDIS.includes(res.status))),
       this.getCluster,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/registry/src/v1/api.gen.ts
+++ b/packages_generated/registry/src/v1/api.gen.ts
@@ -123,8 +123,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!NAMESPACE_TRANSIENT_STATUSES_REGISTRY.includes(res.status))),
       this.getNamespace,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -241,8 +240,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!IMAGE_TRANSIENT_STATUSES_REGISTRY.includes(res.status))),
       this.getImage,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -336,8 +334,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!TAG_TRANSIENT_STATUSES_REGISTRY.includes(res.status))),
       this.getTag,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/s2s_vpn/src/v1alpha1/api.gen.ts
+++ b/packages_generated/s2s_vpn/src/v1alpha1/api.gen.ts
@@ -187,8 +187,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!VPN_GATEWAY_TRANSIENT_STATUSES_S2S_VPN.includes(res.status))),
       this.getVpnGateway,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/searchdb/src/v1alpha1/api.gen.ts
+++ b/packages_generated/searchdb/src/v1alpha1/api.gen.ts
@@ -162,8 +162,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DEPLOYMENT_TRANSIENT_STATUSES_SEARCHDB.includes(res.status))),
       this.getDeployment,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/serverless_sqldb/src/v1alpha1/api.gen.ts
+++ b/packages_generated/serverless_sqldb/src/v1alpha1/api.gen.ts
@@ -110,8 +110,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DATABASE_TRANSIENT_STATUSES_SERVERLESS_SQLDB.includes(res.status))),
       this.getDatabase,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/tem/src/v1alpha1/api.gen.ts
+++ b/packages_generated/tem/src/v1alpha1/api.gen.ts
@@ -159,8 +159,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!EMAIL_TRANSIENT_STATUSES_TEM.includes(res.status))),
       this.getEmail,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -290,8 +289,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DOMAIN_TRANSIENT_STATUSES_TEM.includes(res.status))),
       this.getDomain,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/test/src/v1/api.gen.ts
+++ b/packages_generated/test/src/v1/api.gen.ts
@@ -121,8 +121,7 @@ Hint: you can use other test commands by setting the SCW_SECRET_KEY env variable
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!HUMAN_TRANSIENT_STATUSES_TEST.includes(res.status))),
       this.getHuman,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/vpcgw/src/v2/api.gen.ts
+++ b/packages_generated/vpcgw/src/v2/api.gen.ts
@@ -170,8 +170,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!GATEWAY_TRANSIENT_STATUSES_VPCGW.includes(res.status))),
       this.getGateway,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -311,8 +310,7 @@ export class API extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!GATEWAY_NETWORK_TRANSIENT_STATUSES_VPCGW.includes(res.status))),
       this.getGatewayNetwork,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/packages_generated/webhosting/src/v1/api.gen.ts
+++ b/packages_generated/webhosting/src/v1/api.gen.ts
@@ -230,8 +230,7 @@ export class BackupAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!BACKUP_TRANSIENT_STATUSES_WEBHOSTING.includes(res.status))),
       this.getBackup,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -731,8 +730,7 @@ export class DnsAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!DOMAIN_TRANSIENT_STATUSES_WEBHOSTING.includes(res.status))),
       this.getDomain,
-      request,
-      options,
+      { ...options, request },
     )
 
   
@@ -884,8 +882,7 @@ export class HostingAPI extends ParentAPI {
     waitForResource(
       options?.stop ?? (res => Promise.resolve(!HOSTING_TRANSIENT_STATUSES_WEBHOSTING.includes(res.status))),
       this.getHosting,
-      request,
-      options,
+      { ...options, request },
     )
 
   

--- a/tools/generate-packages/src/commands/deps.ts
+++ b/tools/generate-packages/src/commands/deps.ts
@@ -42,9 +42,9 @@ function discoverPackages(src: string): PkgInfo[] {
 function collectImports(
   srcDir: string,
   importRegex: RegExp,
-  pkgMap: Map<string, PkgInfo>,
-  currentPkgName: string,
+  options: { pkgMap: Map<string, PkgInfo>; currentPkgName: string },
 ): Set<string> {
+  const { pkgMap, currentPkgName } = options
   const imports = new Set<string>()
   for (const file of getAllGenTsFiles(srcDir)) {
     const content = readFileSync(file, 'utf8')
@@ -73,10 +73,15 @@ function syncMissingDeps(pkg: PkgInfo, missing: string[], dryRun: boolean): void
   }
 }
 
-function syncPackage(pkg: PkgInfo, importRegex: RegExp, pkgMap: Map<string, PkgInfo>, dryRun: boolean): boolean {
+function syncPackage(
+  pkg: PkgInfo,
+  importRegex: RegExp,
+  options: { pkgMap: Map<string, PkgInfo>; dryRun: boolean },
+): boolean {
+  const { pkgMap, dryRun } = options
   const srcDir = join(pkg.path, 'src')
   if (!existsSync(srcDir)) return false
-  const imports = collectImports(srcDir, importRegex, pkgMap, pkg.packageJson.name)
+  const imports = collectImports(srcDir, importRegex, { pkgMap, currentPkgName: pkg.packageJson.name })
   const missing = [...imports].filter(imp => !pkg.packageJson.dependencies?.[imp])
   if (missing.length === 0) return false
   syncMissingDeps(pkg, missing, dryRun)
@@ -111,7 +116,7 @@ export const deps = async ({ src, config, dryRun = false }: DepsOptions): Promis
   let updated = 0
 
   for (const pkg of packages) {
-    if (syncPackage(pkg, importRegex, pkgMap, dryRun)) updated++
+    if (syncPackage(pkg, importRegex, { pkgMap, dryRun })) updated++
   }
 
   console.log(`\n📊 Packages updated: ${updated}`)

--- a/tools/generate-packages/src/commands/packages.ts
+++ b/tools/generate-packages/src/commands/packages.ts
@@ -77,9 +77,9 @@ function copyConfigTemplates(fullPath: string): void {
 function processProductDir(
   productDir: string,
   inputPathDir: string,
-  templateString: string,
-  metadataTsTemplateString: string,
+  options: { templateString: string; metadataTsTemplateString: string },
 ): void {
+  const { templateString, metadataTsTemplateString } = options
   const fullPath = join(inputPathDir, productDir)
   if (!statSync(fullPath).isDirectory() || CUSTOM.PRODUCT_EXPORT.has(productDir)) return
 
@@ -110,7 +110,7 @@ export const packages = async ({ src: inputPathDir, runInstall = true }: Package
   const metadataTsTemplateString = readFileSync(TEMPLATES.METADATA_TS, 'utf8')
 
   for (const productDir of readdirSync(inputPathDir)) {
-    processProductDir(productDir, inputPathDir, templateString, metadataTsTemplateString)
+    processProductDir(productDir, inputPathDir, { templateString, metadataTsTemplateString })
   }
 
   if (runInstall) {

--- a/tools/generate-packages/src/commands/sdk.ts
+++ b/tools/generate-packages/src/commands/sdk.ts
@@ -43,7 +43,12 @@ const getGeneratedPackages = (dir: string, excludeSuffix?: string): PackageJSON[
  * @param options.config - Loaded configuration defining SDK targets and filters
  * @param options.runInstall - Run `pnpm install` after updating (default: true)
  */
-function rebuildDeps(sdkPkg: PackageJSON, depType: string, config: Config, validPackages: PackageJSON[]): void {
+function rebuildDeps(
+  sdkPkg: PackageJSON,
+  depType: string,
+  options: { config: Config; validPackages: PackageJSON[] },
+): void {
+  const { config, validPackages } = options
   const field =
     depType === 'dependencies'
       ? 'dependencies'
@@ -63,11 +68,11 @@ function rebuildDeps(sdkPkg: PackageJSON, depType: string, config: Config, valid
 function rebuildAllDeps(
   sdkPkg: PackageJSON,
   s: Config['sdks'][number],
-  config: Config,
-  validPackages: PackageJSON[],
+  options: { config: Config; validPackages: PackageJSON[] },
 ): void {
+  const { config, validPackages } = options
   for (const depType of s.depsTypes) {
-    rebuildDeps(sdkPkg, depType, config, validPackages)
+    rebuildDeps(sdkPkg, depType, { config, validPackages })
   }
 }
 
@@ -88,7 +93,7 @@ function updateSdk(s: Config['sdks'][number], src: string, config: Config): void
   }
   const validPackages = generatedPackages.filter(p => !s.ignoredPackages.includes(p.name))
   const sdkPkg = JSON.parse(readFileSync(s.path, 'utf8')) as PackageJSON
-  rebuildAllDeps(sdkPkg, s, config, validPackages)
+  rebuildAllDeps(sdkPkg, s, { config, validPackages })
   writeFileSync(s.path, `${JSON.stringify(sdkPkg, null, 2)}\n`, 'utf8')
   console.log(`Updated ${s.path} with ${validPackages.length} packages`)
   writeSdkIndex(s, validPackages)

--- a/tools/generate-packages/src/commands/setup.ts
+++ b/tools/generate-packages/src/commands/setup.ts
@@ -82,10 +82,9 @@ function addProductsToSdk(sdkPkgPath: string, newProducts: { name: string }[], s
 async function generateAndUpdateProducts(
   src: string,
   config: Config,
-  sdkPkgPath: string,
-  newProducts: { name: string }[],
-  scope: string,
+  options: { sdkPkgPath: string; newProducts: { name: string }[]; scope: string },
 ): Promise<void> {
+  const { sdkPkgPath, newProducts, scope } = options
   console.log('⚙️  Generating package configs...')
   await runPackages({ src, runInstall: false })
   console.log(`📝 Adding deps to ${sdkPkgPath} (scope: ${scope})...`)
@@ -136,7 +135,7 @@ export const setup = async ({
   const earlyExit = checkEarlyExit(newProducts, dryRun)
   if (earlyExit !== null) return earlyExit
 
-  await generateAndUpdateProducts(src, config, sdkPkgPath, newProducts, scope)
+  await generateAndUpdateProducts(src, config, { sdkPkgPath, newProducts, scope })
   runInstallStep(install)
 
   console.log(`✅ Setup complete: ${newProducts.length} product(s) configured`)

--- a/tools/generate-react-queries/src/generate.ts
+++ b/tools/generate-react-queries/src/generate.ts
@@ -37,29 +37,36 @@ function prepareGeneratedDir(ctx: GenerationContext, folderName: string): string
   return generatedDir
 }
 
+type HookGenOptions = {
+  metadata: QueriesMetadata
+  ctx: GenerationContext
+  packageName: string
+  generatedDir: string
+  folderName: string
+}
+
 function writeListMethodHooks(
   method: QueryMethod,
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  ctx: GenerationContext,
-  packageName: string,
-  generatedDir: string,
-  folderName: string,
+  { metadata, ctx, packageName, generatedDir, folderName }: HookGenOptions,
 ): void {
   if (!(ctx.config.filters.skipCursorAllHooks && method.paginationType === 'cursor')) {
-    const allContent = generateAllQueryHook(method, service, metadata, ctx.config, packageName, ctx.namespaceResolver)
+    const allContent = generateAllQueryHook(method, service, {
+      metadata,
+      config: ctx.config,
+      sdkPackageName: packageName,
+      namespaceResolver: ctx.namespaceResolver,
+    })
     const allFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}AllQuery.ts`
     writeFileSync(join(generatedDir, allFileName), allContent)
   }
 
-  const infiniteContent = generateInfiniteQueryHook(
-    method,
-    service,
+  const infiniteContent = generateInfiniteQueryHook(method, service, {
     metadata,
-    ctx.config,
-    packageName,
-    ctx.namespaceResolver,
-  )
+    config: ctx.config,
+    sdkPackageName: packageName,
+    namespaceResolver: ctx.namespaceResolver,
+  })
   const infiniteFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}InfiniteQuery.ts`
   writeFileSync(join(generatedDir, infiniteFileName), infiniteContent)
 }
@@ -67,24 +74,18 @@ function writeListMethodHooks(
 function writeWaiterHook(
   method: QueryMethod,
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  ctx: GenerationContext,
-  packageName: string,
-  generatedDir: string,
-  folderName: string,
+  { metadata, ctx, packageName, generatedDir, folderName }: HookGenOptions,
 ): void {
   const waiterMethod = {
     ...method,
     methodName: `waitFor${capitalize(method.methodName.replace('get', ''))}`,
   }
-  const waiterContent = generateQueryHook(
-    waiterMethod,
-    service,
+  const waiterContent = generateQueryHook(waiterMethod, service, {
     metadata,
-    ctx.config,
-    packageName,
-    ctx.namespaceResolver,
-  )
+    config: ctx.config,
+    sdkPackageName: packageName,
+    namespaceResolver: ctx.namespaceResolver,
+  })
   const waiterFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${ctx.config.naming.waiterPrefix}${capitalize(method.methodName.replace('get', ''))}Query.ts`
   writeFileSync(join(generatedDir, waiterFileName), waiterContent)
 }
@@ -92,37 +93,34 @@ function writeWaiterHook(
 function writeMethodHooks(
   method: QueryMethod,
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  ctx: GenerationContext,
-  packageName: string,
-  generatedDir: string,
-  folderName: string,
+  { metadata, ctx, packageName, generatedDir, folderName }: HookGenOptions,
 ): void {
-  const hookContent = generateQueryHook(method, service, metadata, ctx.config, packageName, ctx.namespaceResolver)
+  const hookContent = generateQueryHook(method, service, {
+    metadata,
+    config: ctx.config,
+    sdkPackageName: packageName,
+    namespaceResolver: ctx.namespaceResolver,
+  })
   const hookFileName = `${ctx.config.naming.hookPrefix}${capitalize(folderName)}${service.apiClass}${capitalize(method.methodName)}Query.ts`
   writeFileSync(join(generatedDir, hookFileName), hookContent)
 
   if (method.isList) {
-    writeListMethodHooks(method, service, metadata, ctx, packageName, generatedDir, folderName)
+    writeListMethodHooks(method, service, { metadata, ctx, packageName, generatedDir, folderName })
   }
 
   if (method.hasWaiter && !ctx.config.filters.skipWaiters) {
-    writeWaiterHook(method, service, metadata, ctx, packageName, generatedDir, folderName)
+    writeWaiterHook(method, service, { metadata, ctx, packageName, generatedDir, folderName })
   }
 }
 
 function writeServiceHooks(
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  ctx: GenerationContext,
-  packageName: string,
-  generatedDir: string,
-  folderName: string,
+  { metadata, ctx, packageName, generatedDir, folderName }: HookGenOptions,
 ): void {
   console.log(`📝 Generating hooks for ${service.apiClass}`)
   for (const method of service.methods) {
     if (!ctx.skipMethods.has(method.methodName) && !(ctx.config.filters.skipPrivateMethods && method.isPrivate)) {
-      writeMethodHooks(method, service, metadata, ctx, packageName, generatedDir, folderName)
+      writeMethodHooks(method, service, { metadata, ctx, packageName, generatedDir, folderName })
     }
   }
   const reloadContent = generateReloadHook(service, metadata, ctx.config)
@@ -132,11 +130,7 @@ function writeServiceHooks(
 
 function generateServiceHooks(
   services: ServiceMetadata[],
-  metadata: QueriesMetadata,
-  ctx: GenerationContext,
-  packageName: string,
-  generatedDir: string,
-  folderName: string,
+  { metadata, ctx, packageName, generatedDir, folderName }: HookGenOptions,
 ): void {
   const servicesToGenerate = services.filter(service => !ctx.skipServices.has(service.apiClass))
   if (servicesToGenerate.length === 0) {
@@ -144,16 +138,14 @@ function generateServiceHooks(
     return
   }
   for (const service of servicesToGenerate) {
-    writeServiceHooks(service, metadata, ctx, packageName, generatedDir, folderName)
+    writeServiceHooks(service, { metadata, ctx, packageName, generatedDir, folderName })
   }
   const indexContent = generateIndexFile(servicesToGenerate, metadata, ctx.config)
   writeFileSync(join(generatedDir, ctx.config.naming.indexFile), indexContent)
 }
 
 async function processVersionCore(
-  packageName: string,
-  pkgDir: string,
-  version: string,
+  { packageName, pkgDir, version }: { packageName: string; pkgDir: string; version: string },
   ctx: GenerationContext,
 ): Promise<void> {
   const metadata = await loadMetadata(pkgDir, version, ctx.metadataFileName)
@@ -163,14 +155,12 @@ async function processVersionCore(
   }
   const { folderName, services } = metadata
   const generatedDir = prepareGeneratedDir(ctx, folderName)
-  generateServiceHooks(services, metadata, ctx, packageName, generatedDir, folderName)
+  generateServiceHooks(services, { metadata, ctx, packageName, generatedDir, folderName })
   console.log(`✅ Generated hooks for ${folderName}`)
 }
 
 async function processVersion(
-  packageName: string,
-  pkgDir: string,
-  version: string,
+  { packageName, pkgDir, version }: { packageName: string; pkgDir: string; version: string },
   ctx: GenerationContext,
 ): Promise<void> {
   if (ctx.skipVersions.has(`${packageName}@${version}`) || ctx.skipVersions.has(version)) {
@@ -178,7 +168,7 @@ async function processVersion(
     return
   }
   try {
-    await processVersionCore(packageName, pkgDir, version, ctx)
+    await processVersionCore({ packageName, pkgDir, version }, ctx)
   } catch (error) {
     console.error(`    ❌ Error loading ${packageName}/${version}/metadata:`, error)
     throw error
@@ -197,7 +187,7 @@ async function processPackage(packageName: string, pkgDir: string, ctx: Generati
   }
   console.log(`  📦 ${packageName}: ${versions.length} version(s): ${versions.join(', ')}`)
   for (const version of versions) {
-    await processVersion(packageName, pkgDir, version, ctx)
+    await processVersion({ packageName, pkgDir, version }, ctx)
   }
 }
 

--- a/tools/generate-react-queries/src/hook-generators.ts
+++ b/tools/generate-react-queries/src/hook-generators.ts
@@ -37,14 +37,18 @@ function resolveApiNames(folderName: string, service: ServiceMetadata, config: R
   return { apiImportName, apiHookName, apiVarName, apiImportPath }
 }
 
+type ResolveNamesOptions = {
+  metadata: QueriesMetadata
+  config: ReactQueriesConfig
+  sdkPackageName: string
+  namespaceResolver: Map<string, ResolvedNamespace>
+}
+
 /** Derive all naming conventions for a given method + service combination. */
 function resolveNames(
   method: QueryMethod,
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  config: ReactQueriesConfig,
-  sdkPackageName: string,
-  namespaceResolver: Map<string, ResolvedNamespace>,
+  { metadata, config, sdkPackageName, namespaceResolver }: ResolveNamesOptions,
 ) {
   const { folderName } = metadata
   const rawTypes = new Set(config.filters.rawTypes)
@@ -54,7 +58,11 @@ function resolveNames(
   const selfNs: ResolvedNamespace = { packageName: sdkPackageName, ns }
 
   // Resolve the namespace for the return type
-  const returnNsInfo = resolveTypeNamespace(method.returnTypeNamespace, sdkPackageName, ns, namespaceResolver)
+  const returnNsInfo = resolveTypeNamespace(method.returnTypeNamespace, {
+    fallbackPackageName: sdkPackageName,
+    fallbackNs: ns,
+    resolver: namespaceResolver,
+  })
   const returnType = nsType(returnNsInfo.ns, method.returnType, rawTypes)
 
   return {
@@ -78,12 +86,9 @@ function resolveNames(
 export function generateQueryHook(
   method: QueryMethod,
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  config: ReactQueriesConfig,
-  sdkPackageName: string,
-  namespaceResolver: Map<string, ResolvedNamespace>,
+  { metadata, config, sdkPackageName, namespaceResolver }: ResolveNamesOptions,
 ): string {
-  const n = resolveNames(method, service, metadata, config, sdkPackageName, namespaceResolver)
+  const n = resolveNames(method, service, { metadata, config, sdkPackageName, namespaceResolver })
   const hasParams = Boolean(method.paramsType)
   const hookSuffix = `${capitalize(metadata.folderName)}${service.apiClass}${capitalize(method.methodName)}Query`
 
@@ -118,12 +123,16 @@ export function generateQueryHook(
   })
 }
 
+type CollectAllHookImportsOptions = {
+  sdkPackageName: string
+  itemNsInfo: ResolvedNamespace
+  rawItemType: string | undefined
+}
+
 function collectAllHookImports(
   n: ResolvedNames,
   method: QueryMethod,
-  sdkPackageName: string,
-  itemNsInfo: ResolvedNamespace,
-  rawItemType: string | undefined,
+  { sdkPackageName, itemNsInfo, rawItemType }: CollectAllHookImportsOptions,
 ): Map<string, ResolvedNamespace> {
   const nsImports = new Map<string, ResolvedNamespace>()
   if (!n.rawTypes.has(method.paramsType)) {
@@ -142,21 +151,22 @@ function collectAllHookImports(
 export function generateAllQueryHook(
   method: QueryMethod,
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  config: ReactQueriesConfig,
-  sdkPackageName: string,
-  namespaceResolver: Map<string, ResolvedNamespace>,
+  { metadata, config, sdkPackageName, namespaceResolver }: ResolveNamesOptions,
 ): string {
-  const n = resolveNames(method, service, metadata, config, sdkPackageName, namespaceResolver)
+  const n = resolveNames(method, service, { metadata, config, sdkPackageName, namespaceResolver })
   const hookSuffix = `${capitalize(metadata.folderName)}${service.apiClass}${capitalize(method.methodName)}AllQuery`
 
   // Resolve the namespace for the list item type
-  const itemNsInfo = resolveTypeNamespace(method.listItemTypeNamespace, sdkPackageName, n.ns, namespaceResolver)
+  const itemNsInfo = resolveTypeNamespace(method.listItemTypeNamespace, {
+    fallbackPackageName: sdkPackageName,
+    fallbackNs: n.ns,
+    resolver: namespaceResolver,
+  })
 
   const rawItemType = method.listItemType
   const itemType = rawItemType ? nsType(itemNsInfo.ns, rawItemType, n.rawTypes) : n.returnType
 
-  const nsImports = collectAllHookImports(n, method, sdkPackageName, itemNsInfo, rawItemType)
+  const nsImports = collectAllHookImports(n, method, { sdkPackageName, itemNsInfo, rawItemType })
 
   return renderHook({
     apiHookName: n.apiHookName,
@@ -180,12 +190,9 @@ export function generateAllQueryHook(
 export function generateInfiniteQueryHook(
   method: QueryMethod,
   service: ServiceMetadata,
-  metadata: QueriesMetadata,
-  config: ReactQueriesConfig,
-  sdkPackageName: string,
-  namespaceResolver: Map<string, ResolvedNamespace>,
+  { metadata, config, sdkPackageName, namespaceResolver }: ResolveNamesOptions,
 ): string {
-  const n = resolveNames(method, service, metadata, config, sdkPackageName, namespaceResolver)
+  const n = resolveNames(method, service, { metadata, config, sdkPackageName, namespaceResolver })
   const hookSuffix = `${capitalize(metadata.folderName)}${service.apiClass}${capitalize(method.methodName)}InfiniteQuery`
 
   // Collect namespace imports: params type and return type
@@ -234,11 +241,15 @@ export function generateReloadHook(
   })
 }
 
+type CollectListExportsOptions = {
+  config: ReactQueriesConfig
+  baseName: string
+}
+
 function collectListExports(
   method: QueryMethod,
   serviceName: string,
-  config: ReactQueriesConfig,
-  baseName: string,
+  { config, baseName }: CollectListExportsOptions,
 ): string[] {
   const exports = [
     `export { ${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery } from "./${config.naming.hookPrefix}${serviceName}${baseName}InfiniteQuery"`,
@@ -251,11 +262,15 @@ function collectListExports(
   return exports
 }
 
+type CollectMethodExportsOptions = {
+  config: ReactQueriesConfig
+  skipMethods: Set<string>
+}
+
 function collectMethodExports(
   method: QueryMethod,
   serviceName: string,
-  config: ReactQueriesConfig,
-  skipMethods: Set<string>,
+  { config, skipMethods }: CollectMethodExportsOptions,
 ): string[] {
   if (skipMethods.has(method.methodName) || (config.filters.skipPrivateMethods && method.isPrivate)) return []
   const baseName = capitalize(method.methodName)
@@ -263,7 +278,7 @@ function collectMethodExports(
     `export { ${config.naming.hookPrefix}${serviceName}${baseName}Query } from "./${config.naming.hookPrefix}${serviceName}${baseName}Query"`,
   ]
   if (method.isList) {
-    exports.push(...collectListExports(method, serviceName, config, baseName))
+    exports.push(...collectListExports(method, serviceName, { config, baseName }))
   }
   if (method.hasWaiter && !config.filters.skipWaiters) {
     const waiterName = `${config.naming.waiterPrefix}${capitalize(method.methodName.replace(/^get/, ''))}`
@@ -288,7 +303,7 @@ export function generateIndexFile(
     const serviceName = `${capitalize(folderName)}${service.apiClass}`
 
     for (const method of service.methods) {
-      exports.push(...collectMethodExports(method, serviceName, config, skipMethods))
+      exports.push(...collectMethodExports(method, serviceName, { config, skipMethods }))
     }
 
     exports.push(

--- a/tools/generate-react-queries/src/namespace-resolver.ts
+++ b/tools/generate-react-queries/src/namespace-resolver.ts
@@ -38,12 +38,16 @@ function normalizeNsPath(nsPath: string): string {
   return nsPath.replace(/^@scaleway\/sdk-/, '@scaleway-internal/sdk-')
 }
 
+type RegisterNsPathOptions = {
+  packageName: string
+  ns: string
+  resolver: Map<string, ResolvedNamespace>
+}
+
 function registerNsPath(
   nsPath: string,
   ownPathPrefix: string,
-  packageName: string,
-  ns: string,
-  resolver: Map<string, ResolvedNamespace>,
+  { packageName, ns, resolver }: RegisterNsPathOptions,
 ): void {
   const normalized = normalizeNsPath(nsPath)
   if (!resolver.has(normalized) && normalized.startsWith(`${ownPathPrefix}/`)) {
@@ -51,13 +55,15 @@ function registerNsPath(
   }
 }
 
+type RegisterVersionNamespacesOptions = {
+  metadataFileName: string
+  ownPathPrefix: string
+  resolver: Map<string, ResolvedNamespace>
+}
+
 async function registerVersionNamespaces(
-  packageName: string,
-  pkgDir: string,
-  version: string,
-  metadataFileName: string,
-  ownPathPrefix: string,
-  resolver: Map<string, ResolvedNamespace>,
+  { packageName, pkgDir, version }: { packageName: string; pkgDir: string; version: string },
+  { metadataFileName, ownPathPrefix, resolver }: RegisterVersionNamespacesOptions,
 ): Promise<void> {
   try {
     const metadata = await loadMetadata(pkgDir, version, metadataFileName)
@@ -66,7 +72,7 @@ async function registerVersionNamespaces(
     for (const service of metadata.services) {
       for (const method of service.methods) {
         for (const nsPath of [method.returnTypeNamespace, method.listItemTypeNamespace]) {
-          if (nsPath) registerNsPath(nsPath, ownPathPrefix, packageName, ns, resolver)
+          if (nsPath) registerNsPath(nsPath, ownPathPrefix, { packageName, ns, resolver })
         }
       }
     }
@@ -105,7 +111,7 @@ export async function buildNamespaceResolver(config: ReactQueriesConfig): Promis
     const ownPathPrefix = normalizePackagePath(packageName)
 
     for (const version of versions) {
-      await registerVersionNamespaces(packageName, pkgDir, version, metadataFileName, ownPathPrefix, resolver)
+      await registerVersionNamespaces({ packageName, pkgDir, version }, { metadataFileName, ownPathPrefix, resolver })
     }
   }
 
@@ -166,11 +172,15 @@ function deriveFromNamespacePath(nsPath: string): ResolvedNamespace | undefined 
  *    but the path follows the `@scaleway/sdk-<slug>/<version>` convention).
  * 3. Fall back to the current package's namespace.
  */
+type ResolveTypeNamespaceOptions = {
+  fallbackPackageName: string
+  fallbackNs: string
+  resolver: Map<string, ResolvedNamespace>
+}
+
 export function resolveTypeNamespace(
   typeNamespace: string | undefined,
-  fallbackPackageName: string,
-  fallbackNs: string,
-  resolver: Map<string, ResolvedNamespace>,
+  { fallbackPackageName, fallbackNs, resolver }: ResolveTypeNamespaceOptions,
 ): ResolvedNamespace {
   // Only resolve values that look like package paths (e.g. '@scaleway-internal/sdk-rdb/v1').
   // Some metadata entries contain the type name itself instead of a package path.

--- a/tools/generate-react-queries/src/package-exports.ts
+++ b/tools/generate-react-queries/src/package-exports.ts
@@ -26,12 +26,16 @@ function removeSrcFromPath(path: string): string {
     .replace(/^src[\\/]/, '')
 }
 
+type BuildNamespaceExportsOptions = {
+  cleanDirName: string
+  pathKey: 'generatedPath' | 'customPath'
+  keySuffix?: string
+}
+
 function buildNamespaceExports(
   allNamespaces: string[],
   config: ReactQueriesConfig,
-  cleanDirName: string,
-  pathKey: 'generatedPath' | 'customPath',
-  keySuffix = '',
+  { cleanDirName, pathKey, keySuffix = '' }: BuildNamespaceExportsOptions,
 ): Record<string, ExportEntry> {
   const subPath = config[pathKey]
   const directories = allNamespaces.filter(namespace =>
@@ -56,8 +60,15 @@ export function updatePackageJsonExports(config: ReactQueriesConfig): void {
 
   const cleanDirName = removeSrcFromPath(config.outputDir)
 
-  const generatedExportsConfig = buildNamespaceExports(allNamespaces, config, cleanDirName, 'generatedPath')
-  const customExportsConfig = buildNamespaceExports(allNamespaces, config, cleanDirName, 'customPath', '/custom')
+  const generatedExportsConfig = buildNamespaceExports(allNamespaces, config, {
+    cleanDirName,
+    pathKey: 'generatedPath',
+  })
+  const customExportsConfig = buildNamespaceExports(allNamespaces, config, {
+    cleanDirName,
+    pathKey: 'customPath',
+    keySuffix: '/custom',
+  })
 
   const otherStaticExport: Record<string, ExportEntry> = {
     './mocks*': {

--- a/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
@@ -89,8 +89,13 @@ async function loadMetadata(packageName: string, version: string): Promise<Metad
 async function processVersion(
   packageName: string,
   version: string,
-  servicesToSkip: Set<string>,
-  isVersionSkipped: (packageName: string, version: string) => boolean,
+  {
+    servicesToSkip,
+    isVersionSkipped,
+  }: {
+    servicesToSkip: Set<string>
+    isVersionSkipped: (packageName: string, version: string) => boolean
+  },
 ): Promise<ProcessedMetadata | null> {
   if (isVersionSkipped(packageName, version)) {
     stdout.write(`⚠️  Skipping ${packageName}/${version}: excluded by skipVersions\n`)
@@ -111,8 +116,13 @@ async function processVersion(
 
 async function processPackageVersions(
   packageName: string,
-  servicesToSkip: Set<string>,
-  isVersionSkipped: (packageName: string, version: string) => boolean,
+  {
+    servicesToSkip,
+    isVersionSkipped,
+  }: {
+    servicesToSkip: Set<string>
+    isVersionSkipped: (packageName: string, version: string) => boolean
+  },
 ): Promise<ProcessedMetadata> {
   const versions = await loadVersions(packageName)
   if (versions.length === 0) {
@@ -121,7 +131,7 @@ async function processPackageVersions(
   }
   let pkgResult: ProcessedMetadata = {}
   for (const version of versions) {
-    const versionResult = await processVersion(packageName, version, servicesToSkip, isVersionSkipped)
+    const versionResult = await processVersion(packageName, version, { servicesToSkip, isVersionSkipped })
     if (versionResult) pkgResult = { ...pkgResult, ...versionResult }
   }
   return pkgResult
@@ -130,8 +140,7 @@ async function processPackageVersions(
 function setupGenerateAPI(
   dirGenName: string,
   packageNameFilter: string,
-  skipServices: string[],
-  skipVersions: string[],
+  { skipServices, skipVersions }: { skipServices: string[]; skipVersions: string[] },
 ) {
   const dir = join(directoryOfSrcFolder, dirGenName)
   mkdirSync(dir, { recursive: true })
@@ -147,15 +156,21 @@ function setupGenerateAPI(
 
 async function processSdkPackage(
   packageName: string,
-  skipPackages: Set<string>,
-  servicesToSkip: Set<string>,
-  isVersionSkipped: (packageName: string, version: string) => boolean,
+  {
+    skipPackages,
+    servicesToSkip,
+    isVersionSkipped,
+  }: {
+    skipPackages: Set<string>
+    servicesToSkip: Set<string>
+    isVersionSkipped: (packageName: string, version: string) => boolean
+  },
 ): Promise<ProcessedMetadata> {
   if (skipPackages.has(packageName)) {
     stdout.write(`⚠️  Skipping ${packageName}: excluded package\n`)
     return {}
   }
-  return await processPackageVersions(packageName, servicesToSkip, isVersionSkipped)
+  return await processPackageVersions(packageName, { servicesToSkip, isVersionSkipped })
 }
 
 export const generateAPI = async ({
@@ -174,12 +189,17 @@ export const generateAPI = async ({
   const { dir, sdkPackages, skipPackages, servicesToSkip, isVersionSkipped } = setupGenerateAPI(
     dirGenName,
     packageNameFilter,
-    skipServices,
-    skipVersions,
+    {
+      skipServices,
+      skipVersions,
+    },
   )
   let result: ProcessedMetadata = {}
   for (const [packageName] of sdkPackages) {
-    result = { ...result, ...(await processSdkPackage(packageName, skipPackages, servicesToSkip, isVersionSkipped)) }
+    result = {
+      ...result,
+      ...(await processSdkPackage(packageName, { skipPackages, servicesToSkip, isVersionSkipped })),
+    }
   }
   emitFiles({ res: result, sourceFolderGen: dir, sdkFactoryPath })
   generateType(result)

--- a/tools/pnpm-auto-release/src/cli.ts
+++ b/tools/pnpm-auto-release/src/cli.ts
@@ -115,8 +115,7 @@ function publishPackages(root: string, options: ReleaseOptions): void {
 function bumpAndPublish(
   root: string,
   options: ReleaseOptions,
-  affected: WorkspacePackage[],
-  range: string,
+  { affected, range }: { affected: WorkspacePackage[]; range: string },
 ): WorkspacePackage[] {
   createChangesets({ root, range, packages: affected, byCommit: options.byCommit, defaultSummary: CHANGESET_MESSAGE })
   exec('pnpm version -r --no-git-checks --tag-version-prefix ""', { cwd: root, stdio: 'inherit' })
@@ -138,8 +137,7 @@ function pushRelease(root: string, skipPush: boolean, newTags: string[]): void {
 function commitTagAndPush(
   root: string,
   options: ReleaseOptions,
-  affected: WorkspacePackage[],
-  updated: WorkspacePackage[],
+  { affected, updated }: { affected: WorkspacePackage[]; updated: WorkspacePackage[] },
 ): void {
   exec('git add -A', { cwd: root })
   exec('git commit -m "chore(release): publish" --no-verify', { cwd: root })
@@ -159,8 +157,8 @@ function main() {
   const { affected, range } = gatherAffectedPackages(root, options.dryRun)
   if (options.dryRun || affected.length === 0) return
 
-  const updated = bumpAndPublish(root, options, affected, range)
-  commitTagAndPush(root, options, affected, updated)
+  const updated = bumpAndPublish(root, options, { affected, range })
+  commitTagAndPush(root, options, { affected, updated })
   logger('[release] done.')
 }
 

--- a/tools/pnpm-auto-release/src/utils.ts
+++ b/tools/pnpm-auto-release/src/utils.ts
@@ -60,7 +60,11 @@ function tagExists(root: string, tag: string): boolean {
   return localExists || remoteExists
 }
 
-function createTagForPackage(root: string, pkg: Package, newPkg: Package, newTags: string[]): void {
+function createTagForPackage(
+  root: string,
+  pkg: Package,
+  { newPkg, newTags }: { newPkg: Package; newTags: string[] },
+): void {
   const tag = `${pkg.name}@${newPkg.version}`
   if (tagExists(root, tag)) {
     logger(`[release] tag already exists, skipping: ${tag}`)
@@ -83,7 +87,7 @@ export const createTags = ({
   const newTags: string[] = []
   for (const pkg of affectedPackages) {
     const newPkg = updatedPackages.find(({ name }) => name === pkg.name)
-    if (newPkg) createTagForPackage(root, pkg, newPkg, newTags)
+    if (newPkg) createTagForPackage(root, pkg, { newPkg, newTags })
   }
   return newTags
 }
@@ -140,7 +144,11 @@ const createChangesetForPackages = (root: string, packages: Package[], summary: 
   logger(`changeset ${summary} ${names}`)
 }
 
-function processCommit(root: string, line: string, packages: Package[], defaultSummary: string): void {
+function processCommit(
+  root: string,
+  line: string,
+  { packages, defaultSummary }: { packages: Package[]; defaultSummary: string },
+): void {
   const [sha, subject] = line.split('\u001F')
   if (!sha) return
   const changedFiles = exec(`git diff-tree --no-commit-id --name-only -r ${sha}`, { cwd: root })
@@ -177,6 +185,6 @@ export const createChangesets = ({
   const commits = exec(`git log ${range} --format="%H%x1F%s" --no-merges`, { cwd: root })
 
   for (const line of commits.split('\n').filter(Boolean)) {
-    processCommit(root, line, packages, defaultSummary)
+    processCommit(root, line, { packages, defaultSummary })
   }
 }


### PR DESCRIPTION
Closes #3383

Refactor functions with more than 3 parameters to use a single options object, then remove the `eslint/max-params` downgrade so the rule is re-enabled as an error.

- Error classes (`ResourceNotFoundError`, `ResourceExpiredError`, `TooManyRequestsError`, ...) now take an options object for their extra fields, preserving public `readonly` instance properties.
- Client paginator / interval retrier signatures regrouped.
- Generator tooling (`generate-react-queries`, `generate-react-sdk`, `generate-packages`, `pnpm-auto-release`) refactored to ≤3 params.
- Generated `packages_generated/**` call sites updated to match the new `waitForResource`/`tryAtIntervals` signatures.

Verified with `pnpm lint` and `pnpm typecheck`.