### PR TITLE
fix(oxlint): enable eslint/no-await-in-loop as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
     'eslint/init-declarations': 'warn',
     'eslint/max-depth': 'warn',
     'eslint/max-params': 'warn',
-    'eslint/no-await-in-loop': 'warn',
     'eslint/no-bitwise': 'warn',
     'eslint/no-eq-null': 'warn',
     'eslint/no-shadow': 'warn',

--- a/packages/client/src/internal/async/interval-retrier.ts
+++ b/packages/client/src/internal/async/interval-retrier.ts
@@ -109,8 +109,10 @@ export const tryAtIntervals = async <T>(
     // Break if timeout has been reached
     if (timeoutTimestamp <= Date.now() + delay) break
     // Wait before the next retry
+    // eslint-disable-next-line eslint/no-await-in-loop
     await sleep(delay)
     // Retry
+    // eslint-disable-next-line eslint/no-await-in-loop
     const { value, done } = await retry()
     if (done) return value
   }

--- a/packages/client/src/internal/interceptors/composer.ts
+++ b/packages/client/src/internal/interceptors/composer.ts
@@ -43,6 +43,7 @@ export const composeResponseErrorInterceptors =
     let prevError = error
     for (const interceptor of interceptors) {
       try {
+        // eslint-disable-next-line eslint/no-await-in-loop
         const res = await interceptor({ request, error: prevError })
 
         return res

--- a/tools/generate-react-queries/src/generate.ts
+++ b/tools/generate-react-queries/src/generate.ts
@@ -197,6 +197,7 @@ async function processPackage(packageName: string, pkgDir: string, ctx: Generati
   }
   console.log(`  📦 ${packageName}: ${versions.length} version(s): ${versions.join(', ')}`)
   for (const version of versions) {
+    // eslint-disable-next-line eslint/no-await-in-loop
     await processVersion(packageName, pkgDir, version, ctx)
   }
 }
@@ -214,6 +215,7 @@ export async function generateFromMetadata(config: ReactQueriesConfig): Promise<
 
   const sdkPackages = discoverSdkPackages(config)
   for (const [packageName, pkgDir] of sdkPackages) {
+    // eslint-disable-next-line eslint/no-await-in-loop
     await processPackage(packageName, pkgDir, ctx)
   }
 

--- a/tools/generate-react-queries/src/namespace-resolver.ts
+++ b/tools/generate-react-queries/src/namespace-resolver.ts
@@ -105,6 +105,7 @@ export async function buildNamespaceResolver(config: ReactQueriesConfig): Promis
     const ownPathPrefix = normalizePackagePath(packageName)
 
     for (const version of versions) {
+      // eslint-disable-next-line eslint/no-await-in-loop
       await registerVersionNamespaces(packageName, pkgDir, version, metadataFileName, ownPathPrefix, resolver)
     }
   }

--- a/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generate-metadata.ts
@@ -121,6 +121,7 @@ async function processPackageVersions(
   }
   let pkgResult: ProcessedMetadata = {}
   for (const version of versions) {
+    // eslint-disable-next-line eslint/no-await-in-loop
     const versionResult = await processVersion(packageName, version, servicesToSkip, isVersionSkipped)
     if (versionResult) pkgResult = { ...pkgResult, ...versionResult }
   }
@@ -179,6 +180,7 @@ export const generateAPI = async ({
   )
   let result: ProcessedMetadata = {}
   for (const [packageName] of sdkPackages) {
+    // eslint-disable-next-line eslint/no-await-in-loop
     result = { ...result, ...(await processSdkPackage(packageName, skipPackages, servicesToSkip, isVersionSkipped)) }
   }
   emitFiles({ res: result, sourceFolderGen: dir, sdkFactoryPath })


### PR DESCRIPTION
Closes #3384

Enable `eslint/no-await-in-loop` as an error by removing its downgrade in `oxlint.config.ts`.

The remaining loops that `await` inside a loop are intentionally sequential and cannot be converted to `Promise.all` without changing behavior or racing on shared output, so they carry an `// eslint-disable-next-line eslint/no-await-in-loop` directive (matching the repo's existing convention):
- `interval-retrier.ts` retry/polling loop (must await sequentially between retries)
- `composer.ts` response-error fallback loop (each interceptor depends on the previous failure)
- generator loops (`generate.ts`, `namespace-resolver.ts`, `generate-metadata.ts`) that write to shared output dirs or accumulate results in order

Verified with `pnpm lint` and `pnpm typecheck`.