### PR TITLE
fix(oxlint): enable typescript/consistent-indexed-object-style as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -44,7 +44,6 @@ export default defineConfig({
     'node/no-process-env': 'warn',
     'oxc/no-accumulating-spread': 'warn',
     'react/set-state-in-effect': 'warn',
-    'typescript/consistent-indexed-object-style': 'warn',
     'typescript/consistent-type-definitions': 'warn',
     'typescript/explicit-member-accessibility': 'warn',
     'typescript/method-signature-style': 'warn',

--- a/packages/client/src/helpers/json.ts
+++ b/packages/client/src/helpers/json.ts
@@ -1,6 +1,8 @@
+// oxlint-disable-next-line typescript/consistent-indexed-object-style -- recursive type cannot use Record<string, JSON> (TS2456 circular reference)
 export type JSON = string | number | boolean | null | JSON[] | { [key: string]: JSON }
 
 export interface JSONObject {
+  // oxlint-disable-next-line typescript/consistent-indexed-object-style -- recursive type cannot use Record<string, JSON> (TS2456 circular reference)
   [key: string]: JSON
 }
 

--- a/packages/client/src/scw/fetch/resource-paginator.ts
+++ b/packages/client/src/scw/fetch/resource-paginator.ts
@@ -9,9 +9,7 @@ interface PaginatedResponse {
 
 export type PaginatedFetcher<T, R extends PaginationOptions = PaginationOptions> = (request: R) => Promise<T>
 
-export type PaginatedContent<K extends string, T = unknown> = PaginatedResponse & {
-  [key in K]: T[]
-}
+export type PaginatedContent<K extends string, T = unknown> = PaginatedResponse & Record<K, T[]>
 
 export const extract =
   <K extends string>(key: K) =>

--- a/tools/generate-packages/src/types.ts
+++ b/tools/generate-packages/src/types.ts
@@ -11,8 +11,8 @@ export type PackageJSON = {
   name: string
   version: string
   path: string
-  dependencies?: { [key: string]: string }
-  devDependencies?: { [key: string]: string }
-  peerDependencies?: { [key: string]: string }
-  optionalDependencies?: { [key: string]: string }
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
 }

--- a/tools/generate-react-sdk/src/metadata-types.ts
+++ b/tools/generate-react-sdk/src/metadata-types.ts
@@ -33,9 +33,10 @@ export type Metadata = {
 }
 
 /** Processed result for code generation */
-export type ProcessedMetadata = {
-  [namespace: string]: {
+export type ProcessedMetadata = Record<
+  string,
+  {
     packageName: string
     apis: string[]
   }
-}
+>


### PR DESCRIPTION
Closes #3396

Enable `typescript/consistent-indexed-object-style` as an error:
- Convert non-recursive index signatures to `Record<...>` in `resource-paginator.ts`, `generate-packages/src/types.ts`, and `generate-react-sdk/src/metadata-types.ts`.
- The recursive `JSON`/`JSONObject` types in `packages/client/src/helpers/json.ts` cannot use `Record<string, JSON>` (TS2456 circular reference), so those two index signatures are kept with a targeted oxlint-disable.
- Remove the downgrade line from `oxlint.config.ts`.