### PR TITLE
fix(oxlint): enable typescript/no-confusing-void-expression as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -48,7 +48,6 @@ export default defineConfig({
     'typescript/consistent-type-definitions': 'warn',
     'typescript/explicit-member-accessibility': 'warn',
     'typescript/method-signature-style': 'warn',
-    'typescript/no-confusing-void-expression': 'warn',
     'typescript/no-dynamic-delete': 'warn',
     'typescript/no-redundant-type-constituents': 'warn',
     'typescript/no-unnecessary-boolean-literal-compare': 'warn',

--- a/packages/client/src/internal/logger/index.ts
+++ b/packages/client/src/internal/logger/index.ts
@@ -23,8 +23,9 @@ export const setLogger = (logger: Readonly<Logger>) => {
  *
  * @public
  */
-export const enableConsoleLogger = (logLevel: LogLevel = 'warn', prefix = 'scaleway-sdk-js:') =>
+export const enableConsoleLogger = (logLevel: LogLevel = 'warn', prefix = 'scaleway-sdk-js:'): void => {
   setLogger(new ConsoleLogger(logLevel, prefix))
+}
 
 /**
  * Returns the active SDK logger.

--- a/packages/client/src/scw/__tests__/custom-marshalling.test.ts
+++ b/packages/client/src/scw/__tests__/custom-marshalling.test.ts
@@ -147,7 +147,7 @@ describe('unmarshalDecimal', () => {
 })
 
 describe('marshalScwFile', () => {
-  it('returns a the proper object', () =>
+  it('returns a the proper object', () => {
     expect(
       marshalScwFile({
         content: 'eyJoZWxsbyI6IndvcmxkIn0=',
@@ -158,7 +158,8 @@ describe('marshalScwFile', () => {
       content: 'eyJoZWxsbyI6IndvcmxkIn0=',
       content_type: 'text/plain',
       name: 'filename',
-    }))
+    })
+  })
 })
 
 describe('marshalMoney', () => {

--- a/packages/client/src/scw/fetch/__tests__/http-interceptors.test.ts
+++ b/packages/client/src/scw/fetch/__tests__/http-interceptors.test.ts
@@ -30,7 +30,9 @@ beforeEach(() => {
   latestMessage = ''
 })
 
-afterAll(() => setLogger(new ConsoleLogger('silent')))
+afterAll(() => {
+  setLogger(new ConsoleLogger('silent'))
+})
 
 describe(`logRequest`, () => {
   const request = new Request('https://api.scaleway.com')

--- a/packages/client/src/scw/fetch/__tests__/resource-paginator.test.ts
+++ b/packages/client/src/scw/fetch/__tests__/resource-paginator.test.ts
@@ -13,7 +13,9 @@ const fetchPages = <T>(input: T[][] = [], delay = 0) => {
     }
 
     return new Promise<typeof page>(resolve => {
-      setTimeout(() => resolve(page), delay)
+      setTimeout(() => {
+        resolve(page)
+      }, delay)
     })
   }
 }

--- a/tools/generate-packages/src/commands/setup.ts
+++ b/tools/generate-packages/src/commands/setup.ts
@@ -50,7 +50,10 @@ function discoverNewProducts(src: string): { name: string }[] {
 
 function logNewProducts(newProducts: { name: string }[]): void {
   console.log(`📦 New products: ${newProducts.length}`)
-  if (newProducts.length > 0) newProducts.forEach(p => console.log(`  - ${p.name}`))
+  if (newProducts.length > 0)
+    newProducts.forEach(p => {
+      console.log(`  - ${p.name}`)
+    })
 }
 
 function checkEarlyExit(newProducts: { name: string }[], dryRun: boolean): number | null {


### PR DESCRIPTION
Closes #3397

Enables `typescript/no-confusing-void-expression` as error by fixing all violations and removing the warn override from `oxlint.config.ts`.