### PR TITLE
fix(oxlint): enable typescript/no-unnecessary-boolean-literal-compare as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -51,7 +51,6 @@ export default defineConfig({
     'typescript/no-confusing-void-expression': 'warn',
     'typescript/no-dynamic-delete': 'warn',
     'typescript/no-redundant-type-constituents': 'warn',
-    'typescript/no-unnecessary-boolean-literal-compare': 'warn',
     'typescript/no-unnecessary-condition': 'warn',
     'typescript/no-unnecessary-template-expression': 'warn',
     'typescript/no-unnecessary-type-conversion': 'warn',

--- a/tools/pnpm-auto-release/src/cli.ts
+++ b/tools/pnpm-auto-release/src/cli.ts
@@ -67,18 +67,18 @@ function parseReleaseArgs(): ReleaseOptions | null {
     logger(HELP)
     return null
   }
-  if (values['gh-release'] === true) {
+  if (values['gh-release']) {
     const ghToken = process.env['GH_TOKEN'] || process.env['GITHUB_TOKEN']
     if (!ghToken) {
       throw new Error('GH_TOKEN environment variable is required for creating GitHub releases')
     }
   }
   return {
-    dryRun: values['dry-run'] === true,
-    skipPublish: values['skip-publish'] === true,
-    skipPush: values['skip-push'] === true,
-    byCommit: values['by-commit'] === true,
-    ghRelease: values['gh-release'] === true,
+    dryRun: values['dry-run'],
+    skipPublish: values['skip-publish'],
+    skipPush: values['skip-push'],
+    byCommit: values['by-commit'],
+    ghRelease: values['gh-release'],
     registry: values.registry,
   }
 }


### PR DESCRIPTION
Closes #3398

Enables `typescript/no-unnecessary-boolean-literal-compare` as error by fixing all violations and removing the warn override from `oxlint.config.ts`.