### PR TITLE
fix(oxlint): enable typescript/no-unnecessary-template-expression as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -53,7 +53,6 @@ export default defineConfig({
     'typescript/no-redundant-type-constituents': 'warn',
     'typescript/no-unnecessary-boolean-literal-compare': 'warn',
     'typescript/no-unnecessary-condition': 'warn',
-    'typescript/no-unnecessary-template-expression': 'warn',
     'typescript/no-unnecessary-type-conversion': 'warn',
     'typescript/no-unnecessary-type-parameters': 'warn',
     'typescript/no-unsafe-assignment': 'warn',

--- a/tools/generate-react-sdk/src/generateAPI/generateType.ts
+++ b/tools/generate-react-sdk/src/generateAPI/generateType.ts
@@ -15,7 +15,7 @@ function buildExportLines(res: ProcessedMetadata): string[] {
   for (const [name, { apis }] of Object.entries(res)) {
     const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1)
     for (const api of apis) {
-      const key = `${lowerCaseFirstLetter(name + api.replace('API', ''))}`
+      const key = lowerCaseFirstLetter(name + api.replace('API', ''))
       const type = `${capitalizedName}.${api}`
       lines.push(`${key}:${type},\n`)
     }


### PR DESCRIPTION
Enable `typescript/no-unnecessary-template-expression` as an error by removing its `warn` downgrade and fixing all violations across the codebase.

Closes #3400