### PR TITLE
fix(oxlint): enable eslint/default-case as error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
 
     // Downgrade base-preset error rules to warn (to be fixed and re-enabled as error)
     'eslint/curly': 'warn',
-    'eslint/default-case': 'warn',
     'eslint/eqeqeq': 'warn',
     'eslint/init-declarations': 'warn',
     'eslint/max-depth': 'warn',

--- a/tools/generate-packages/src/cli.ts
+++ b/tools/generate-packages/src/cli.ts
@@ -76,4 +76,6 @@ switch (command) {
       install: Boolean(values.install),
     })
     break
+  default:
+    break
 }


### PR DESCRIPTION
Closes #3380

Fixes all `eslint/default-case` violations and re-enables the rule as an error in `oxlint.config.ts`.